### PR TITLE
upgrade dependencies for npm package

### DIFF
--- a/.npm/package-lock.json
+++ b/.npm/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "{{ PACKAGE_NAME }}",
-  "version": "something",
+  "version": "{{ PACKAGE_VERSION }}",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "{{ PACKAGE_NAME }}",
-      "version": "something",
+      "version": "{{ PACKAGE_VERSION }}",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.0",
-        "tar": "^6.1.11",
+        "axios": "^1.6.8",
+        "tar": "^6.1.0",
         "unzip-stream": "^0.3.1"
       },
       "bin": {
@@ -24,11 +24,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -254,11 +254,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/.npm/package.json
+++ b/.npm/package.json
@@ -23,8 +23,8 @@
   },
   "main": "couper-binary.js",
   "dependencies": {
-    "axios": "^1.6.0",
-    "tar": "^6.1.11",
+    "axios": "^1.6.8",
+    "tar": "^6.1.0",
     "unzip-stream": "^0.3.1"
   }
 }


### PR DESCRIPTION
Axios was out of date and had a security vulnerability:

```
axios  0.8.1 - 0.27.2
Severity: moderate
Axios Cross-Site Request Forgery Vulnerability - https://github.com/advisories/GHSA-wf5p-g6vw-rhxx
No fix available
node_modules/couper/node_modules/axios
  couper  *
  Depends on vulnerable versions of axios
  node_modules/couper
```

See https://github.com/advisories/GHSA-wf5p-g6vw-rhxx for more details

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
