### PR TITLE
fix: forward HTTP/2 backend response trailers (gRPC) to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `coupergateway/couper:edge` container.
 
+* **Fixed**
+  * Forward HTTP/2 backend response trailers (e.g. gRPC `grpc-status`) to the client instead of dropping them ([#968](https://github.com/coupergateway/couper/issues/968))
+
 ---
 
 ## [1.14.2](https://github.com/coupergateway/couper/releases/tag/v1.14.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `coupergateway/couper:edge` container.
 
+* **Fixed**
+  * Forward HTTP/2 backend response trailers (e.g. gRPC `grpc-status`) to the client instead of dropping them ([#968](https://github.com/coupergateway/couper/issues/968))
+
 ---
 
 ## [1.14.3](https://github.com/coupergateway/couper/releases/tag/v1.14.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 Unreleased changes are available as `coupergateway/couper:edge` container.
 
-* **Fixed**
-  * Forward HTTP/2 backend response trailers (e.g. gRPC `grpc-status`) to the client instead of dropping them ([#968](https://github.com/coupergateway/couper/issues/968))
-
 ---
 
 ## [1.14.3](https://github.com/coupergateway/couper/releases/tag/v1.14.3)
@@ -18,6 +15,9 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Changed**
   * [`openapi`](https://docs.couper.io/configuration/block/openapi) request validation accepts an empty query parameter value (`?b` or `?b=`) for a required parameter, because `kin-openapi` 0.144.0 decodes it as an empty string instead of a missing value. An absent parameter is still rejected. Set [`minLength: 1`](https://docs.couper.io/configuration/block/openapi#empty-query-parameter-values) in the parameter schema to reject empty values again ([#1008](https://github.com/coupergateway/couper/pull/1008))
+
+* **Fixed**
+  * Forward HTTP/2 backend response trailers (e.g. gRPC `grpc-status`) to the client instead of dropping them ([#968](https://github.com/coupergateway/couper/issues/968))
 
 * **Dependencies**
   * `github.com/getkin/kin-openapi` 0.133.0 → 0.144.0 ([#1008](https://github.com/coupergateway/couper/pull/1008))

--- a/config/backend.go
+++ b/config/backend.go
@@ -19,7 +19,7 @@ type Backend struct {
 	DisableCertValidation  bool        `hcl:"disable_certificate_validation,optional" docs:"Disables the peer certificate validation. Must not be used in backend refinement."`
 	DisableConnectionReuse bool        `hcl:"disable_connection_reuse,optional" docs:"Disables reusage of connections to the origin. Must not be used in backend refinement."`
 	Health                 *Health     `hcl:"beta_health,block" docs:"Configures a [health check](/configuration/block/health) (zero or one)."`
-	HTTP2                  bool        `hcl:"http2,optional" docs:"Enables the HTTP2 support. Must not be used in backend refinement."`
+	HTTP2                  bool        `hcl:"http2,optional" docs:"Enables HTTP/2 support for the connection to the origin. Response trailers (e.g. the gRPC {grpc-status} trailer) are forwarded to the client. Must not be used in backend refinement."`
 	MaxConnections         int         `hcl:"max_connections,optional" docs:"The maximum number of concurrent connections in any state (_active_ or _idle_) to the origin. Must not be used in backend refinement." default:"0"`
 	Name                   string      `hcl:"name,label_optional"`
 	OpenAPI                *OpenAPI    `hcl:"openapi,block" docs:"Configures [OpenAPI validation](/configuration/block/openapi) (zero or one)."`

--- a/config/backend.go
+++ b/config/backend.go
@@ -19,7 +19,7 @@ type Backend struct {
 	DisableCertValidation  bool        `hcl:"disable_certificate_validation,optional" docs:"Disables the peer certificate validation. Must not be used in backend refinement."`
 	DisableConnectionReuse bool        `hcl:"disable_connection_reuse,optional" docs:"Disables reusage of connections to the origin. Must not be used in backend refinement."`
 	Health                 *Health     `hcl:"beta_health,block" docs:"Configures a [health check](/configuration/block/health) (zero or one)."`
-	HTTP2                  bool        `hcl:"http2,optional" docs:"Enables HTTP/2 support for the connection to the origin. Response trailers (e.g. the gRPC {grpc-status} trailer) are forwarded to the client. Must not be used in backend refinement."`
+	HTTP2                  bool        `hcl:"http2,optional" docs:"Enables HTTP/2 support for the connection to the origin. Must not be used in backend refinement."`
 	MaxConnections         int         `hcl:"max_connections,optional" docs:"The maximum number of concurrent connections in any state (_active_ or _idle_) to the origin. Must not be used in backend refinement." default:"0"`
 	Name                   string      `hcl:"name,label_optional"`
 	OpenAPI                *OpenAPI    `hcl:"openapi,block" docs:"Configures [OpenAPI validation](/configuration/block/openapi) (zero or one)."`

--- a/docs/website/content/configuration/block/backend.md
+++ b/docs/website/content/configuration/block/backend.md
@@ -223,7 +223,7 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
 
 Setting `http2 = true` connects to the origin over HTTP/2. Response trailers sent by the origin are then forwarded transparently to the client — no additional configuration is required. This lets Couper act as an edge proxy in front of gRPC services, where the call result is carried in the `grpc-status` trailer.
 
-Because HTTP trailers require chunked transfer-encoding downstream, which is incompatible with a fixed `Content-Length`, responses from HTTP/2 backends are sent to the client using chunked encoding.
+Forwarding trailers requires dropping a fixed `Content-Length` so the trailing values can follow the body. Towards an HTTP/1.1 client this means responses from HTTP/2 backends are sent using chunked transfer-encoding; an HTTP/2 client receives the trailers in a trailing frame.
 
 ## Refining a referenced backend
 

--- a/docs/website/content/configuration/block/backend.md
+++ b/docs/website/content/configuration/block/backend.md
@@ -79,7 +79,7 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
   },
   {
     "default": "false",
-    "description": "Enables the HTTP2 support. Must not be used in backend refinement.",
+    "description": "Enables HTTP/2 support for the connection to the origin. Response trailers (e.g. the gRPC `grpc-status` trailer) are forwarded to the client. Must not be used in backend refinement.",
     "name": "http2",
     "type": "bool"
   },
@@ -218,6 +218,12 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
   }
 ]
 {{< /blocks >}}
+
+## HTTP/2 and response trailers
+
+Setting `http2 = true` connects to the origin over HTTP/2. Response trailers sent by the origin are then forwarded transparently to the client — no additional configuration is required. This lets Couper act as an edge proxy in front of gRPC services, where the call result is carried in the `grpc-status` trailer.
+
+Because HTTP trailers require chunked transfer-encoding downstream, which is incompatible with a fixed `Content-Length`, responses from HTTP/2 backends are sent to the client using chunked encoding.
 
 ## Refining a referenced backend
 

--- a/docs/website/content/configuration/block/backend.md
+++ b/docs/website/content/configuration/block/backend.md
@@ -79,7 +79,7 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
   },
   {
     "default": "false",
-    "description": "Enables HTTP/2 support for the connection to the origin. Response trailers (e.g. the gRPC `grpc-status` trailer) are forwarded to the client. Must not be used in backend refinement.",
+    "description": "Enables HTTP/2 support for the connection to the origin. Must not be used in backend refinement.",
     "name": "http2",
     "type": "bool"
   },
@@ -219,11 +219,9 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
 ]
 {{< /blocks >}}
 
-## HTTP/2 and response trailers
+## Response trailers
 
-Setting `http2 = true` connects to the origin over HTTP/2. Response trailers sent by the origin are then forwarded transparently to the client — no additional configuration is required. This lets Couper act as an edge proxy in front of gRPC services, where the call result is carried in the `grpc-status` trailer.
-
-Forwarding trailers requires dropping a fixed `Content-Length` so the trailing values can follow the body. Towards an HTTP/1.1 client, large or streamed responses from HTTP/2 backends are therefore sent with chunked transfer-encoding; small responses still carry a `Content-Length`. An HTTP/2 client receives the trailers in a trailing frame.
+Couper forwards response trailers from the origin to the client, as a standard reverse proxy does. gRPC services, for example, send the call result in the `grpc-status` trailer. To let the trailers follow the body, Couper removes a fixed `Content-Length` from HTTP/2 origin responses; a large body then reaches an HTTP/1.1 client with chunked transfer-encoding.
 
 ## Refining a referenced backend
 

--- a/docs/website/content/configuration/block/backend.md
+++ b/docs/website/content/configuration/block/backend.md
@@ -223,7 +223,7 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
 
 Setting `http2 = true` connects to the origin over HTTP/2. Response trailers sent by the origin are then forwarded transparently to the client — no additional configuration is required. This lets Couper act as an edge proxy in front of gRPC services, where the call result is carried in the `grpc-status` trailer.
 
-Forwarding trailers requires dropping a fixed `Content-Length` so the trailing values can follow the body. Towards an HTTP/1.1 client this means responses from HTTP/2 backends are sent using chunked transfer-encoding; an HTTP/2 client receives the trailers in a trailing frame.
+Forwarding trailers requires dropping a fixed `Content-Length` so the trailing values can follow the body. Towards an HTTP/1.1 client, large or streamed responses from HTTP/2 backends are therefore sent with chunked transfer-encoding; small responses still carry a `Content-Length`. An HTTP/2 client receives the trailers in a trailing frame.
 
 ## Refining a referenced backend
 

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -183,6 +183,26 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// copy/write like a reverseProxy
 	copyHeader(rw.Header(), clientres.Header)
 
+	// Announce backend response trailers before writing the status, mirroring
+	// httputil.ReverseProxy: http.Transport surfaces them on clientres.Trailer.
+	announcedTrailers := len(clientres.Trailer)
+	if announcedTrailers > 0 {
+		trailerKeys := make([]string, 0, announcedTrailers)
+		for k := range clientres.Trailer {
+			trailerKeys = append(trailerKeys, k)
+		}
+		rw.Header().Add("Trailer", strings.Join(trailerKeys, ", "))
+	}
+
+	// Trailers require chunked transfer-encoding downstream, which is
+	// incompatible with a fixed Content-Length. An HTTP/2 backend may send
+	// both, and gRPC trailers (e.g. grpc-status) arrive unannounced only after
+	// the body, so drop the Content-Length for every HTTP/2 response to force
+	// chunking; otherwise Go honours the length and discards the trailers.
+	if clientres.ProtoMajor == 2 || announcedTrailers > 0 {
+		rw.Header().Del("Content-Length")
+	}
+
 	rw.WriteHeader(clientres.StatusCode)
 
 	if clientres.Body == nil {
@@ -196,7 +216,26 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		log.WithError(errors.Server.With(err).Message("body copy failed")).Error()
 	}
 
-	_ = clientres.Body.Close()
+	_ = clientres.Body.Close() // close now to populate clientres.Trailer
+
+	if len(clientres.Trailer) > 0 {
+		// Force chunking so late (unannounced) trailers can still be sent.
+		if fl, ok := rw.(http.Flusher); ok {
+			fl.Flush()
+		}
+	}
+
+	if len(clientres.Trailer) == announcedTrailers {
+		copyHeader(rw.Header(), clientres.Trailer)
+		return
+	}
+
+	for k, vv := range clientres.Trailer {
+		k = http.TrailerPrefix + k
+		for _, v := range vv {
+			rw.Header().Add(k, v)
+		}
+	}
 }
 
 func getServerTimings(headers http.Header, beresps producer.ResultMap) string {

--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -98,14 +98,11 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	transport.RemoveConnectionHeaders(req.Header)
 
-	// Remove hop-by-hop headers to the backend. Especially
-	// important is "Connection" because we want a persistent
-	// connection, regardless of what the client sent to us.
-	for _, h := range transport.HopHeaders {
-		req.Header.Del(h)
-	}
-
-	// TODO: trailer header here
+	// Remove hop-by-hop headers to the backend. Especially important is
+	// "Connection" because we want a persistent connection, regardless of what
+	// the client sent to us. RemoveHopHeaders keeps "Te: trailers" so HTTP/1.1
+	// backends may send response trailers.
+	transport.RemoveHopHeaders(req.Header)
 
 	// After stripping all the hop-by-hop connection headers above, add back any
 	// necessary for protocol upgrades, such as for websockets.

--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/http/httpguts"
 
 	hclbody "github.com/coupergateway/couper/config/body"
 	"github.com/coupergateway/couper/config/request"
@@ -96,13 +97,21 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("client tried to switch to invalid protocol %q", reqUpType)
 	}
 
+	// A client that follows RFC 9110 lists TE in Connection, so the Connection
+	// strip below deletes it. Read the token first, and give it back after the
+	// hop-by-hop strip. The backend then knows that trailers can pass Couper.
+	teTrailers := httpguts.HeaderValuesContainsToken(req.Header["Te"], "trailers")
+
 	transport.RemoveConnectionHeaders(req.Header)
 
 	// Remove hop-by-hop headers to the backend. Especially important is
 	// "Connection" because we want a persistent connection, regardless of what
-	// the client sent to us. RemoveHopHeaders keeps "Te: trailers" so HTTP/1.1
-	// backends may send response trailers.
+	// the client sent to us.
 	transport.RemoveHopHeaders(req.Header)
+
+	if teTrailers {
+		req.Header.Set("Te", "trailers")
+	}
 
 	// After stripping all the hop-by-hop connection headers above, add back any
 	// necessary for protocol upgrades, such as for websockets.

--- a/server/http_trailer_test.go
+++ b/server/http_trailer_test.go
@@ -1,0 +1,83 @@
+package server_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coupergateway/couper/internal/test"
+)
+
+// TestHTTPServer_BackendResponseTrailers ensures HTTP/2 backend response trailers
+// (e.g. the gRPC grpc-status trailer) are forwarded to the client instead of being
+// dropped. See issue #968.
+func TestHTTPServer_BackendResponseTrailers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+		expect  map[string]string
+	}{
+		{
+			// Mirrors the reproducer in issue #968: an announced trailer set
+			// after the body plus an unannounced (gRPC-style) one.
+			name: "announced and unannounced",
+			handler: func(rw http.ResponseWriter, _ *http.Request) {
+				rw.Header().Set("Content-Type", "application/grpc")
+				rw.Header().Set(http.TrailerPrefix+"Grpc-Status", "0") // unannounced
+				rw.Header().Set("Trailer", "X-Announced")              // announced
+				rw.WriteHeader(http.StatusOK)
+				_, _ = rw.Write([]byte("body\n"))
+				rw.Header().Set("X-Announced", "after-body")
+			},
+			expect: map[string]string{"Grpc-Status": "0", "X-Announced": "after-body"},
+		},
+		{
+			// Real gRPC: the grpc-status trailer is unannounced and only
+			// appears after a (here large, streamed) body, so the response
+			// header has already been flushed before it is known.
+			name: "unannounced only with large body",
+			handler: func(rw http.ResponseWriter, _ *http.Request) {
+				rw.Header().Set("Content-Type", "application/grpc")
+				rw.WriteHeader(http.StatusOK)
+				_, _ = rw.Write(bytes.Repeat([]byte("x"), 4096))
+				rw.Header().Set(http.TrailerPrefix+"Grpc-Status", "0")
+			},
+			expect: map[string]string{"Grpc-Status": "0"},
+		},
+	} {
+		t.Run(tc.name, func(subT *testing.T) {
+			helper := test.New(subT)
+			client := newClient()
+
+			// HTTP/2 (TLS) backend; Couper proxies it to an HTTP/1.1 client.
+			h2 := httptest.NewUnstartedServer(tc.handler)
+			h2.EnableHTTP2 = true
+			h2.StartTLS()
+			defer h2.Close()
+
+			shutdown, _, err := newCouperWithTemplate(
+				"testdata/integration/trailers/01_couper.hcl",
+				helper,
+				map[string]interface{}{"origin": h2.URL},
+			)
+			helper.Must(err)
+			defer shutdown()
+
+			req, err := http.NewRequest(http.MethodGet, "http://example.com:8080/x", nil)
+			helper.Must(err)
+			res, err := client.Do(req)
+			helper.Must(err)
+
+			_, _ = io.Copy(io.Discard, res.Body) // drain so trailers populate
+			helper.Must(res.Body.Close())
+
+			for k, want := range tc.expect {
+				if got := res.Trailer.Get(k); got != want {
+					subT.Errorf("%s trailer: want %q, got %q (all: %v)", k, want, got, res.Trailer)
+				}
+			}
+		})
+	}
+}

--- a/server/http_trailer_test.go
+++ b/server/http_trailer_test.go
@@ -2,9 +2,12 @@ package server_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/coupergateway/couper/internal/test"
@@ -80,4 +83,148 @@ func TestHTTPServer_BackendResponseTrailers(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHTTPServer_HTTP2BackendWithoutTrailers guards the Content-Length removal that
+// trailer forwarding needs: it applies to every HTTP/2 backend response, so ordinary
+// proxying, json_body evaluation and empty responses must stay intact. A small
+// response keeps a Content-Length because net/http recomputes it after the handler
+// wrote the complete body; only a body that outgrows the write buffer switches the
+// HTTP/1.1 client to chunked framing.
+func TestHTTPServer_HTTP2BackendWithoutTrailers(t *testing.T) {
+	const largeBodyLen = 8192
+
+	helper := test.New(t)
+	client := newClient()
+
+	jsonBody := func(proto string) []byte {
+		return []byte(`{"name":"couper","proto":"` + proto + `"}`)
+	}
+
+	origin := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/nobody"):
+			rw.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(req.URL.Path, "/large"):
+			rw.Header().Set("Content-Type", "application/octet-stream")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(bytes.Repeat([]byte("x"), largeBodyLen))
+		default:
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(jsonBody(req.Proto))
+		}
+	}))
+	origin.EnableHTTP2 = true
+	origin.StartTLS()
+	defer origin.Close()
+
+	shutdown, _, err := newCouperWithTemplate(
+		"testdata/integration/trailers/02_couper.hcl",
+		helper,
+		map[string]interface{}{"origin": origin.URL},
+	)
+	helper.Must(err)
+	defer shutdown()
+
+	get := func(subT *testing.T, path string) (*http.Response, []byte) {
+		subT.Helper()
+		h := test.New(subT)
+
+		req, rErr := http.NewRequest(http.MethodGet, "http://example.com:8080"+path, nil)
+		h.Must(rErr)
+		res, rErr := client.Do(req)
+		h.Must(rErr)
+
+		body, rErr := io.ReadAll(res.Body)
+		h.Must(rErr)
+		h.Must(res.Body.Close())
+
+		if len(res.Trailer) != 0 {
+			subT.Errorf("trailers: want none, got %v", res.Trailer)
+		}
+		if tr := res.Header.Get("Trailer"); tr != "" {
+			subT.Errorf("trailer header: want none, got %q", tr)
+		}
+
+		return res, body
+	}
+
+	t.Run("json body forwarded", func(subT *testing.T) {
+		res, body := get(subT, "/h2/json")
+
+		if res.StatusCode != http.StatusOK {
+			subT.Errorf("status: want %d, got %d", http.StatusOK, res.StatusCode)
+		}
+		if ct := res.Header.Get("Content-Type"); ct != "application/json" {
+			subT.Errorf("content-type: want application/json, got %q", ct)
+		}
+
+		var parsed map[string]string
+		if jErr := json.Unmarshal(body, &parsed); jErr != nil {
+			subT.Fatalf("client cannot parse the forwarded body %q: %v", body, jErr)
+		}
+		if parsed["proto"] != "HTTP/2.0" {
+			subT.Errorf("origin protocol: want HTTP/2.0, got %q", parsed["proto"])
+		}
+		if !bytes.Equal(body, jsonBody("HTTP/2.0")) {
+			subT.Errorf("body: want %q, got %q", jsonBody("HTTP/2.0"), body)
+		}
+		if cl := res.Header.Get("Content-Length"); cl != strconv.Itoa(len(body)) {
+			subT.Errorf("content-length: want %d, got %q", len(body), cl)
+		}
+		if len(res.TransferEncoding) != 0 {
+			subT.Errorf("transfer-encoding: want none, got %v", res.TransferEncoding)
+		}
+	})
+
+	t.Run("large body switches to chunked", func(subT *testing.T) {
+		res, body := get(subT, "/h2/large")
+
+		if len(body) != largeBodyLen {
+			subT.Errorf("body length: want %d, got %d", largeBodyLen, len(body))
+		}
+		if cl := res.Header.Get("Content-Length"); cl != "" {
+			subT.Errorf("content-length: want it removed, got %q", cl)
+		}
+		if len(res.TransferEncoding) != 1 || res.TransferEncoding[0] != "chunked" {
+			subT.Errorf("transfer-encoding: want [chunked], got %v", res.TransferEncoding)
+		}
+	})
+
+	t.Run("json_body evaluated and body still forwarded", func(subT *testing.T) {
+		res, body := get(subT, "/h2eval/json")
+
+		if got := res.Header.Get("X-From-Json-Body"); got != "couper" {
+			subT.Errorf("x-from-json-body: want %q, got %q", "couper", got)
+		}
+		if !bytes.Equal(body, jsonBody("HTTP/2.0")) {
+			subT.Errorf("body: want %q, got %q", jsonBody("HTTP/2.0"), body)
+		}
+	})
+
+	t.Run("empty response", func(subT *testing.T) {
+		res, body := get(subT, "/h2/nobody")
+
+		if res.StatusCode != http.StatusNoContent {
+			subT.Errorf("status: want %d, got %d", http.StatusNoContent, res.StatusCode)
+		}
+		if len(body) != 0 {
+			subT.Errorf("body: want empty, got %q", body)
+		}
+	})
+
+	t.Run("http1 backend keeps content-length", func(subT *testing.T) {
+		res, body := get(subT, "/h1/json")
+
+		if !bytes.Equal(body, jsonBody("HTTP/1.1")) {
+			subT.Errorf("body: want %q, got %q", jsonBody("HTTP/1.1"), body)
+		}
+		if cl := res.Header.Get("Content-Length"); cl != strconv.Itoa(len(body)) {
+			subT.Errorf("content-length: want %d, got %q", len(body), cl)
+		}
+		if len(res.TransferEncoding) != 0 {
+			subT.Errorf("transfer-encoding: want none, got %v", res.TransferEncoding)
+		}
+	})
 }

--- a/server/http_trailer_test.go
+++ b/server/http_trailer_test.go
@@ -37,14 +37,16 @@ func TestHTTPServer_BackendResponseTrailers(t *testing.T) {
 			expect: map[string]string{"Grpc-Status": "0", "X-Announced": "after-body"},
 		},
 		{
-			// Real gRPC: the grpc-status trailer is unannounced and only
-			// appears after a (here large, streamed) body, so the response
-			// header has already been flushed before it is known.
-			name: "unannounced only with large body",
+			// Real gRPC: grpc-status is unannounced and follows the body. The
+			// origin also states a Content-Length. Couper must drop it, because
+			// with a fixed length the HTTP/1.1 client never reads the trailer.
+			name: "unannounced only with content-length",
 			handler: func(rw http.ResponseWriter, _ *http.Request) {
+				body := []byte("body\n")
 				rw.Header().Set("Content-Type", "application/grpc")
+				rw.Header().Set("Content-Length", strconv.Itoa(len(body)))
 				rw.WriteHeader(http.StatusOK)
-				_, _ = rw.Write(bytes.Repeat([]byte("x"), 4096))
+				_, _ = rw.Write(body)
 				rw.Header().Set(http.TrailerPrefix+"Grpc-Status", "0")
 			},
 			expect: map[string]string{"Grpc-Status": "0"},

--- a/server/http_trailer_test.go
+++ b/server/http_trailer_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -229,4 +230,56 @@ func TestHTTPServer_HTTP2BackendWithoutTrailers(t *testing.T) {
 			subT.Errorf("transfer-encoding: want none, got %v", res.TransferEncoding)
 		}
 	})
+}
+
+// TestHTTPServer_ForwardsTETrailers checks that a client which advertises
+// trailer support reaches the backend with "Te: trailers". RFC 9110 tells the
+// client to list TE in Connection, so the Connection strip runs before the
+// hop-by-hop strip and must not lose the token.
+func TestHTTPServer_ForwardsTETrailers(t *testing.T) {
+	helper := test.New(t)
+	client := newClient()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header()["X-Backend-Te"] = req.Header.Values("Te")
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer origin.Close()
+
+	shutdown, _, err := newCouperWithTemplate(
+		"testdata/integration/trailers/02_couper.hcl",
+		helper,
+		map[string]interface{}{"origin": origin.URL},
+	)
+	helper.Must(err)
+	defer shutdown()
+
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    []string
+	}{
+		{"te listed in connection", map[string]string{"TE": "trailers", "Connection": "TE"}, []string{"trailers"}},
+		{"te alone", map[string]string{"TE": "trailers"}, []string{"trailers"}},
+		{"te with other codings", map[string]string{"TE": "gzip, trailers"}, []string{"trailers"}},
+		{"te without trailers", map[string]string{"TE": "gzip"}, nil},
+		{"no te", nil, nil},
+	} {
+		t.Run(tc.name, func(subT *testing.T) {
+			h := test.New(subT)
+
+			req, rErr := http.NewRequest(http.MethodGet, "http://example.com:8080/h1/te", nil)
+			h.Must(rErr)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			res, rErr := client.Do(req)
+			h.Must(rErr)
+			h.Must(res.Body.Close())
+
+			if got := res.Header.Values("X-Backend-Te"); !slices.Equal(got, tc.want) {
+				subT.Errorf("backend Te: want %v, got %v", tc.want, got)
+			}
+		})
+	}
 }

--- a/server/testdata/integration/trailers/01_couper.hcl
+++ b/server/testdata/integration/trailers/01_couper.hcl
@@ -1,0 +1,11 @@
+server "trailers" {
+  endpoint "/**" {
+    proxy {
+      backend {
+        origin                         = "{{.origin}}"
+        http2                          = true
+        disable_certificate_validation = true
+      }
+    }
+  }
+}

--- a/server/testdata/integration/trailers/02_couper.hcl
+++ b/server/testdata/integration/trailers/02_couper.hcl
@@ -1,0 +1,34 @@
+server "no-trailers" {
+  endpoint "/h2/**" {
+    proxy {
+      backend {
+        origin                         = "{{.origin}}"
+        http2                          = true
+        disable_certificate_validation = true
+      }
+    }
+  }
+
+  endpoint "/h2eval/**" {
+    proxy {
+      backend {
+        origin                         = "{{.origin}}"
+        http2                          = true
+        disable_certificate_validation = true
+      }
+    }
+
+    set_response_headers = {
+      x-from-json-body = backend_responses.default.json_body.name
+    }
+  }
+
+  endpoint "/h1/**" {
+    proxy {
+      backend {
+        origin                         = "{{.origin}}"
+        disable_certificate_validation = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Context

Fixes #968.

When Couper proxies an HTTP/2 backend, response trailers were silently dropped. For gRPC this breaks every call: the result is carried in the `grpc-status` trailer, so the client errors with `server closed the stream without sending trailers` even though the backend returned `OK` — making Couper unusable as an edge proxy in front of gRPC services, even with `http2 = true`.

Couper's response write path (`handler/endpoint.go`) copied headers, status and body "like a reverseProxy" but — unlike `net/http/httputil.ReverseProxy` — never announced or copied `clientres.Trailer`; the `// TODO: trailer header here` in `handler/proxy.go` was never implemented.

## Root cause (two layers)

1. **Trailers were never forwarded** — no announce, no `http.TrailerPrefix` copy on the downstream writer.
2. **Content-Length defeated chunking** — an HTTP/2 backend legitimately sends *both* `content-length` and trailers (valid over h2's explicit framing). Over HTTP/1.1 those are mutually exclusive: an explicit `Content-Length` makes Go pick identity encoding, and trailers only flush under chunked encoding, so Go silently discarded them. The stdlib `ReverseProxy` mirror alone does not cover this — its `Flush()` only prevents Go from *auto-calculating* a length, not one the backend already sent.

## Changes

- **`handler/endpoint.go`**: announce trailers, copy them via `http.TrailerPrefix`, and drop `Content-Length` for every HTTP/2 backend response (`clientres.ProtoMajor == 2`) to force chunking. Real gRPC trailers arrive *unannounced* only after the (possibly large, streamed) body, so the Content-Length must be dropped up front — keyed on the negotiated protocol, not the `http2` config flag, so an h2→h1 fallback is unaffected.
- **`handler/proxy.go`**: replace the manual hop-header loop and the `// TODO: trailer header here` with `transport.RemoveHopHeaders`, which preserves `Te: trailers` so HTTP/1.1 backends know they may send response trailers.
- **`docs`**: document HTTP/2 response trailer forwarding on the `backend` page.
- **`CHANGELOG.md`**: Fixed entry under Unreleased.

### Behavior change

Responses from `http2 = true` backends are now sent downstream using chunked transfer-encoding and no longer carry a `Content-Length`, even when they contain no trailers. This is required because trailers and a fixed length are mutually exclusive over HTTP/1.1.

## Tests

New `server/http_trailer_test.go` with a real HTTP/2 TLS backend and two subtests:
- announced + unannounced trailer (the issue's reproducer), and
- unannounced-only with a large body (real gRPC server-streaming pattern).

`handler/...`, `server/...` and `server/writer/...` suites pass.