### PR TITLE
beta_external_authz: expose callout response as request.context.<label> (2/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Added**
   * `beta_authz_external` access control: delegate the authorization decision to an external service via an HTTP callout, with distinct `authz_external_invalid_credentials` (401) and `authz_external_insufficient_permissions` (403) error types and opt-in TLS connection metadata (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
+  * expose the JSON object response body of a `beta_authz_external` callout as the `request.context.<label>` variable ([#873](https://github.com/coupergateway/couper/issues/873))
 
 ---
 

--- a/accesscontrol/authz/external.go
+++ b/accesscontrol/authz/external.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"io"
+	"mime"
 	"net/http"
 	"time"
 
 	"github.com/coupergateway/couper/config/request"
 	"github.com/coupergateway/couper/errors"
 	"github.com/coupergateway/couper/eval"
+	"github.com/coupergateway/couper/eval/buffer"
 )
 
 const roundTripName = "authz_external"
@@ -113,7 +116,10 @@ func (e *External) Validate(req *http.Request) error {
 	outreq.Header.Set("Content-Type", "application/json")
 	eval.SetBody(outreq, body)
 
-	ctx, cancel := context.WithCancel(context.WithValue(req.Context(), request.RoundTripName, roundTripName))
+	outCtx := context.WithValue(req.Context(), request.RoundTripName, roundTripName)
+	// keep the response body readable with a non default roundtrip name
+	outCtx = context.WithValue(outCtx, request.BufferOptions, buffer.Option(buffer.Response))
+	ctx, cancel := context.WithCancel(outCtx)
 	defer cancel()
 
 	res, err := e.transport.RoundTrip(outreq.WithContext(ctx))
@@ -124,7 +130,7 @@ func (e *External) Validate(req *http.Request) error {
 
 	switch res.StatusCode {
 	case http.StatusOK:
-		return nil
+		return e.storeContext(req, res)
 	case http.StatusUnauthorized:
 		return errors.AuthzExternalInvalidCredentials.Label(e.name).Message("invalid credentials")
 	case http.StatusForbidden:
@@ -132,4 +138,37 @@ func (e *External) Validate(req *http.Request) error {
 	default:
 		return errors.AuthzExternal.Label(e.name).Messagef("unexpected authorization service response status: %d", res.StatusCode)
 	}
+}
+
+// storeContext exposes a JSON object response body as request.context.<label>.
+// A malformed body denies the request: silently dropping data which
+// downstream permission checks may rely on would fail open.
+func (e *External) storeContext(req *http.Request, res *http.Response) error {
+	mediaType, _, _ := mime.ParseMediaType(res.Header.Get("Content-Type"))
+	if mediaType != "application/json" {
+		return nil
+	}
+
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		return errors.AuthzExternal.Label(e.name).With(err)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var data map[string]interface{}
+	if err = json.Unmarshal(raw, &data); err != nil {
+		return errors.AuthzExternal.Label(e.name).Message("unexpected authorization service response body").With(err)
+	}
+
+	ctx := req.Context()
+	acMap, ok := ctx.Value(request.AccessControls).(map[string]interface{})
+	if !ok {
+		acMap = make(map[string]interface{})
+	}
+	acMap[e.name] = data
+	*req = *req.WithContext(context.WithValue(ctx, request.AccessControls, acMap))
+
+	return nil
 }

--- a/accesscontrol/authz/external_test.go
+++ b/accesscontrol/authz/external_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coupergateway/couper/accesscontrol/authz"
+	"github.com/coupergateway/couper/config/request"
 	"github.com/coupergateway/couper/errors"
 )
 
@@ -115,6 +116,100 @@ func TestExternal_Validate_CalloutRequest(t *testing.T) {
 	if headers == nil || headers["Authorization"] == nil {
 		t.Errorf("expected serialized authorization header, got: %v", clientRequest["headers"])
 	}
+}
+
+func TestExternal_Validate_ContextPropagation(t *testing.T) {
+	respondBody := func(contentType, body string) roundTripperFunc {
+		return func(_ *http.Request) (*http.Response, error) {
+			rec := httptest.NewRecorder()
+			if contentType != "" {
+				rec.Header().Set("Content-Type", contentType)
+			}
+			rec.WriteHeader(http.StatusOK)
+			_, _ = rec.WriteString(body)
+			return rec.Result(), nil
+		}
+	}
+
+	contextData := func(req *http.Request) map[string]interface{} {
+		acMap, _ := req.Context().Value(request.AccessControls).(map[string]interface{})
+		data, _ := acMap["test_ac"].(map[string]interface{})
+		return data
+	}
+
+	t.Run("json object response lands in access control context", func(t *testing.T) {
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+			respondBody("application/json", `{"sub":"clark.kent","roles":["reporter"]}`))
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		data := contextData(req)
+		if data == nil {
+			t.Fatal("missing access control context data")
+		}
+		if data["sub"] != "clark.kent" {
+			t.Errorf("unexpected sub: %v", data["sub"])
+		}
+		roles, _ := data["roles"].([]interface{})
+		if len(roles) != 1 || roles[0] != "reporter" {
+			t.Errorf("unexpected roles: %v", data["roles"])
+		}
+	})
+
+	t.Run("invalid json fails closed", func(t *testing.T) {
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+			respondBody("application/json", `{"sub":`))
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		err := external.Validate(req)
+
+		cErr, ok := err.(*errors.Error)
+		if !ok {
+			t.Fatalf("expected *errors.Error, got: %T", err)
+		}
+		if kinds := cErr.Kinds(); len(kinds) == 0 || kinds[0] != "authz_external" {
+			t.Errorf("expected error kind authz_external, got: %v", kinds)
+		}
+	})
+
+	t.Run("non-object json fails closed", func(t *testing.T) {
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+			respondBody("application/json", `[1,2]`))
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		if err := external.Validate(req); err == nil {
+			t.Error("expected an error for a non-object json response")
+		}
+	})
+
+	t.Run("empty body stores nothing", func(t *testing.T) {
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+			respondBody("application/json", ""))
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if data := contextData(req); data != nil {
+			t.Errorf("expected no context data, got: %v", data)
+		}
+	})
+
+	t.Run("non-json content type stores nothing", func(t *testing.T) {
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+			respondBody("text/plain", "OK"))
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if data := contextData(req); data != nil {
+			t.Errorf("expected no context data, got: %v", data)
+		}
+	})
 }
 
 func TestExternal_Validate_IncludeTLS(t *testing.T) {

--- a/docs/website/content/configuration/block/beta_authz_external.md
+++ b/docs/website/content/configuration/block/beta_authz_external.md
@@ -59,6 +59,11 @@ The response status code of the authorization service determines the decision:
 | `403`     | Denied with error type `authz_external_insufficient_permissions`, default response status `403`. |
 | any other | Denied with error type `authz_external`, default response status `401`.                    |
 
+If the `200` response carries a JSON object body (`Content-Type: application/json`), that
+object becomes accessible as the [`request.context.<label>` variable](/configuration/variables#context) —
+the place for validated claims, the resolved identity or granted permissions. A malformed
+JSON body denies the request, as downstream permission checks may rely on this data.
+
 The error types can be handled with [`error_handler` blocks](/configuration/error-handling),
 for example to send a `WWW-Authenticate` challenge pointing OAuth 2.0 clients to the
 protected resource metadata (RFC 9728).

--- a/docs/website/content/configuration/variables.md
+++ b/docs/website/content/configuration/variables.md
@@ -68,6 +68,8 @@ The value of `context.<name>` depends on the type of block referenced by `<name>
 
 For a [`basic_auth` block](/configuration/block/basic_auth) and successfully authenticated request the variable contains the `user` name.
 
+For a [`beta_authz_external` block](/configuration/block/beta_authz_external) the variable contains the JSON object body of the authorization service's `200` response (if any), e.g. validated claims or resolved permissions.
+
 For a [`jwt` block](/configuration/block/jwt) the variable contains claims from the JWT used for [access control](/configuration/access-control).
 
 For a [`saml` block](/configuration/block/saml) the variable contains

--- a/server/http_authz_external_test.go
+++ b/server/http_authz_external_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -57,6 +58,43 @@ func TestAuthzExternal_Callout(t *testing.T) {
 				st.Errorf("expected logged error_type %q, got: %q", tc.expErrorType, loggedType)
 			}
 		})
+	}
+}
+
+func TestAuthzExternal_ContextPropagation(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	shutdown, hook := newCouper("testdata/authz_external/03_couper.hcl", helper)
+	defer shutdown()
+	hook.Reset()
+
+	req, err := http.NewRequest(http.MethodGet, "http://protected.local:8080/protected", nil)
+	helper.Must(err)
+
+	res, err := client.Do(req)
+	helper.Must(err)
+	resBytes, err := io.ReadAll(res.Body)
+	helper.Must(err)
+	_ = res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got: %d", http.StatusOK, res.StatusCode)
+	}
+
+	if sub := res.Header.Get("X-Authz-Sub"); sub != "clark.kent" {
+		t.Errorf("expected authz context sub header, got: %q", sub)
+	}
+
+	var body map[string]interface{}
+	helper.Must(json.Unmarshal(resBytes, &body))
+
+	if body["sub"] != "clark.kent" {
+		t.Errorf("unexpected sub: %v", body["sub"])
+	}
+	roles, _ := body["roles"].([]interface{})
+	if len(roles) != 2 || roles[0] != "reporter" || roles[1] != "hero" {
+		t.Errorf("unexpected roles: %v", body["roles"])
 	}
 }
 

--- a/server/testdata/authz_external/03_couper.hcl
+++ b/server/testdata/authz_external/03_couper.hcl
@@ -1,0 +1,37 @@
+server "protected" {
+  hosts = ["*:8080"]
+
+  api {
+    endpoint "/protected" {
+      access_control = ["authz"]
+
+      response {
+        headers = {
+          x-authz-sub = request.context.authz.sub
+        }
+        json_body = request.context.authz
+      }
+    }
+  }
+}
+
+server "authz-service" {
+  hosts = ["*:8081"]
+
+  api {
+    endpoint "/check" {
+      response {
+        json_body = {
+          sub   = "clark.kent"
+          roles = ["reporter", "hero"]
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  beta_authz_external "authz" {
+    url = "http://127.0.0.1:8081/check"
+  }
+}


### PR DESCRIPTION
refs #873 — stacked on #874, merge after it (part 2/5).

## Context

Allow/deny alone is not enough: when `beta_authz_external` replaces a `jwt` block (necessary for OR-semantics between credential types), downstream HCL loses `request.context.<label>.claims`. Claim-driven features (`required_permission`, #935's `allowed_tools`) need the callout's validated data in the evaluation context (DESIGN.md §1).

## This PR

- A JSON object body (`Content-Type: application/json`) of the authorization service's 200 response is stored in the access-control context map (same mechanism as the `beta_oauth2` callback) and becomes `request.context.<label>.*`
- Fail closed: malformed or non-object JSON on 200 denies the request — silently dropping data that downstream permission checks rely on would fail open; empty bodies / non-JSON content types simply store nothing
- Callout now sets buffer options so the response body stays readable with a non-default round-trip name
- Unit + integration tests, docs (block page, variables page), CHANGELOG


Assisted by [Claude Code](https://claude.ai/code)
