### PR TITLE
beta_external_authz: expose callout response headers in request.context (3/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Added**
   * `beta_authz_external` access control: delegate the authorization decision to an external service via an HTTP callout, with distinct `authz_external_invalid_credentials` (401) and `authz_external_insufficient_permissions` (403) error types and opt-in TLS connection metadata (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
-  * expose the JSON object response body of a `beta_authz_external` callout as the `request.context.<label>` variable ([#873](https://github.com/coupergateway/couper/issues/873))
+  * expose a `beta_authz_external` callout's JSON object response body and its response headers (`request.context.<label>` / `request.context.<label>.headers`); inject a resolved identity upstream with `set_request_headers` ([#873](https://github.com/coupergateway/couper/issues/873))
 
 ---
 

--- a/accesscontrol/authz/external.go
+++ b/accesscontrol/authz/external.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/coupergateway/couper/config/request"
 	"github.com/coupergateway/couper/errors"
 	"github.com/coupergateway/couper/eval"
 	"github.com/coupergateway/couper/eval/buffer"
+	"github.com/coupergateway/couper/internal/seetie"
 )
 
 const roundTripName = "authz_external"
@@ -168,7 +168,7 @@ func (e *External) storeContext(req *http.Request, res *http.Response) error {
 		}
 	}
 
-	data["headers"] = responseHeaders(res.Header)
+	data["headers"] = seetie.HeaderToMap(res.Header)
 
 	ctx := req.Context()
 	acMap, ok := ctx.Value(request.AccessControls).(map[string]interface{})
@@ -179,18 +179,4 @@ func (e *External) storeContext(req *http.Request, res *http.Response) error {
 	*req = *req.WithContext(context.WithValue(ctx, request.AccessControls, acMap))
 
 	return nil
-}
-
-// responseHeaders renders callout response headers like request.headers: lower-cased names
-// mapped to the first value.
-func responseHeaders(header http.Header) map[string]interface{} {
-	m := make(map[string]interface{}, len(header))
-	for name, values := range header {
-		value := ""
-		if len(values) > 0 {
-			value = values[0]
-		}
-		m[strings.ToLower(name)] = value
-	}
-	return m
 }

--- a/accesscontrol/authz/external.go
+++ b/accesscontrol/authz/external.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/coupergateway/couper/config/request"
@@ -140,27 +141,34 @@ func (e *External) Validate(req *http.Request) error {
 	}
 }
 
-// storeContext exposes a JSON object response body as request.context.<label>.
-// A malformed body denies the request: silently dropping data which
-// downstream permission checks may rely on would fail open.
+// storeContext exposes the callout response as request.context.<label>: the properties of a
+// JSON object response body, plus the response headers under a "headers" property (lower-cased
+// names, first value, matching request.headers). Consumers inject a resolved identity or a
+// re-signed internal token upstream by reading these and writing set_request_headers, which
+// overwrites client-provided values. A malformed JSON body denies the request, as downstream
+// permission checks may rely on it. A body property literally named "headers" is shadowed by
+// the response headers.
 func (e *External) storeContext(req *http.Request, res *http.Response) error {
+	data := map[string]interface{}{}
+
 	mediaType, _, _ := mime.ParseMediaType(res.Header.Get("Content-Type"))
-	if mediaType != "application/json" {
-		return nil
+	if mediaType == "application/json" {
+		raw, err := io.ReadAll(res.Body)
+		if err != nil {
+			return errors.AuthzExternal.Label(e.name).With(err)
+		}
+		if len(raw) > 0 {
+			var body map[string]interface{}
+			if err = json.Unmarshal(raw, &body); err != nil {
+				return errors.AuthzExternal.Label(e.name).Message("unexpected authorization service response body").With(err)
+			}
+			for name, value := range body {
+				data[name] = value
+			}
+		}
 	}
 
-	raw, err := io.ReadAll(res.Body)
-	if err != nil {
-		return errors.AuthzExternal.Label(e.name).With(err)
-	}
-	if len(raw) == 0 {
-		return nil
-	}
-
-	var data map[string]interface{}
-	if err = json.Unmarshal(raw, &data); err != nil {
-		return errors.AuthzExternal.Label(e.name).Message("unexpected authorization service response body").With(err)
-	}
+	data["headers"] = responseHeaders(res.Header)
 
 	ctx := req.Context()
 	acMap, ok := ctx.Value(request.AccessControls).(map[string]interface{})
@@ -171,4 +179,18 @@ func (e *External) storeContext(req *http.Request, res *http.Response) error {
 	*req = *req.WithContext(context.WithValue(ctx, request.AccessControls, acMap))
 
 	return nil
+}
+
+// responseHeaders renders callout response headers like request.headers: lower-cased names
+// mapped to the first value.
+func responseHeaders(header http.Header) map[string]interface{} {
+	m := make(map[string]interface{}, len(header))
+	for name, values := range header {
+		value := ""
+		if len(values) > 0 {
+			value = values[0]
+		}
+		m[strings.ToLower(name)] = value
+	}
+	return m
 }

--- a/accesscontrol/authz/external_test.go
+++ b/accesscontrol/authz/external_test.go
@@ -159,6 +159,28 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 		}
 	})
 
+	t.Run("response headers are exposed under headers", func(t *testing.T) {
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+			roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+				rec := httptest.NewRecorder()
+				rec.Header().Set("Content-Type", "application/json")
+				rec.Header().Set("X-Resolved-Identity", "clark.kent")
+				rec.WriteHeader(http.StatusOK)
+				_, _ = rec.WriteString(`{"sub":"clark.kent"}`)
+				return rec.Result(), nil
+			}))
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		headers, _ := contextData(req)["headers"].(map[string]interface{})
+		if headers["x-resolved-identity"] != "clark.kent" {
+			t.Errorf("expected lower-cased x-resolved-identity, got: %v", headers)
+		}
+	})
+
 	t.Run("invalid json fails closed", func(t *testing.T) {
 		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
 			respondBody("application/json", `{"sub":`))
@@ -185,7 +207,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 		}
 	})
 
-	t.Run("empty body stores nothing", func(t *testing.T) {
+	t.Run("empty body still exposes headers", func(t *testing.T) {
 		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
 			respondBody("application/json", ""))
 
@@ -193,12 +215,12 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 		if err := external.Validate(req); err != nil {
 			t.Fatalf("expected no error, got: %v", err)
 		}
-		if data := contextData(req); data != nil {
-			t.Errorf("expected no context data, got: %v", data)
+		if _, ok := contextData(req)["headers"]; !ok {
+			t.Error("expected headers in context data")
 		}
 	})
 
-	t.Run("non-json content type stores nothing", func(t *testing.T) {
+	t.Run("non-json response exposes headers without body properties", func(t *testing.T) {
 		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
 			respondBody("text/plain", "OK"))
 
@@ -206,8 +228,12 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 		if err := external.Validate(req); err != nil {
 			t.Fatalf("expected no error, got: %v", err)
 		}
-		if data := contextData(req); data != nil {
-			t.Errorf("expected no context data, got: %v", data)
+		data := contextData(req)
+		if _, ok := data["headers"]; !ok {
+			t.Error("expected headers in context data")
+		}
+		if data["sub"] != nil {
+			t.Errorf("expected no body properties, got: %v", data)
 		}
 	})
 }

--- a/docs/website/content/configuration/block/beta_authz_external.md
+++ b/docs/website/content/configuration/block/beta_authz_external.md
@@ -59,10 +59,33 @@ The response status code of the authorization service determines the decision:
 | `403`     | Denied with error type `authz_external_insufficient_permissions`, default response status `403`. |
 | any other | Denied with error type `authz_external`, default response status `401`.                    |
 
-If the `200` response carries a JSON object body (`Content-Type: application/json`), that
-object becomes accessible as the [`request.context.<label>` variable](/configuration/variables#context) —
-the place for validated claims, the resolved identity or granted permissions. A malformed
-JSON body denies the request, as downstream permission checks may rely on this data.
+The `200` response is exposed as the [`request.context.<label>` variable](/configuration/variables#context):
+the properties of a JSON object body (`Content-Type: application/json`) — the place for validated
+claims, the resolved identity or granted permissions — plus the response headers under
+`request.context.<label>.headers` (lower-cased names, first value, like `request.headers`).
+A malformed JSON body denies the request, as downstream permission checks may rely on this data.
+A body property literally named `headers` is shadowed by the response headers.
+
+An upstream backend can trust a resolved identity or a re-signed internal token (created with
+[`jwt_sign()`](/configuration/functions)) the authorization service returns as a header, by
+copying it onto the request with `set_request_headers` — which overwrites any client-provided
+value:
+
+```hcl
+api {
+  endpoint "/**" {
+    access_control = ["authz"]
+
+    proxy {
+      backend = "protected_api"
+
+      set_request_headers = {
+        x-resolved-identity = request.context.authz.headers["x-resolved-identity"]
+      }
+    }
+  }
+}
+```
 
 The error types can be handled with [`error_handler` blocks](/configuration/error-handling),
 for example to send a `WWW-Authenticate` challenge pointing OAuth 2.0 clients to the

--- a/internal/seetie/convert.go
+++ b/internal/seetie/convert.go
@@ -168,14 +168,23 @@ func MapToValue(m map[string]interface{}) cty.Value {
 	return cty.ObjectVal(ctyMap)
 }
 
-func HeaderToMapValue(headers http.Header) cty.Value {
-	ctyMap := make(map[string]cty.Value)
+// HeaderToMap renders headers as lower-cased names mapped to their first value.
+func HeaderToMap(headers http.Header) map[string]interface{} {
+	m := make(map[string]interface{}, len(headers))
 	for k, v := range headers {
 		if len(v) == 0 {
-			ctyMap[strings.ToLower(k)] = cty.StringVal("")
+			m[strings.ToLower(k)] = ""
 			continue
 		}
-		ctyMap[strings.ToLower(k)] = cty.StringVal(v[0]) // TODO: ListVal??
+		m[strings.ToLower(k)] = v[0] // TODO: ListVal??
+	}
+	return m
+}
+
+func HeaderToMapValue(headers http.Header) cty.Value {
+	ctyMap := make(map[string]cty.Value)
+	for k, v := range HeaderToMap(headers) {
+		ctyMap[k] = cty.StringVal(v.(string))
 	}
 	if len(ctyMap) == 0 {
 		return cty.MapValEmpty(cty.String)

--- a/server/http_authz_external_test.go
+++ b/server/http_authz_external_test.go
@@ -98,6 +98,37 @@ func TestAuthzExternal_ContextPropagation(t *testing.T) {
 	}
 }
 
+func TestAuthzExternal_ResponseHeaders(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	shutdown, hook := newCouper("testdata/authz_external/04_couper.hcl", helper)
+	defer shutdown()
+	hook.Reset()
+
+	req, err := http.NewRequest(http.MethodGet, "http://protected.local:8080/protected", nil)
+	helper.Must(err)
+	req.Header.Set("X-Resolved-Identity", "spoofed")
+
+	res, err := client.Do(req)
+	helper.Must(err)
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got: %d", http.StatusOK, res.StatusCode)
+	}
+
+	// The callout's response header is exposed in request.context and wins over the
+	// client-provided value; a header the service did not return is empty.
+	if identity := res.Header.Get("X-Identity"); identity != "clark.kent" {
+		t.Errorf("expected resolved identity from the callout, got: %q", identity)
+	}
+	if evil := res.Header.Get("X-Evil"); evil != "" {
+		t.Errorf("expected no value for an unset callout header, got: %q", evil)
+	}
+}
+
 func TestAuthzExternal_ErrorHandler(t *testing.T) {
 	client := newClient()
 	helper := test.New(t)

--- a/server/testdata/authz_external/04_couper.hcl
+++ b/server/testdata/authz_external/04_couper.hcl
@@ -1,0 +1,42 @@
+server "protected" {
+  hosts = ["*:8080"]
+
+  api {
+    endpoint "/protected" {
+      access_control = ["authz"]
+
+      # The resolved identity from the callout response header is injected explicitly;
+      # set_request_headers would overwrite a client-provided value the same way.
+      response {
+        headers = {
+          x-identity = request.context.authz.headers["x-resolved-identity"]
+          x-evil     = request.context.authz.headers["x-evil"]
+        }
+      }
+    }
+  }
+}
+
+server "authz-service" {
+  hosts = ["*:8081"]
+
+  api {
+    endpoint "/check" {
+      response {
+        headers = {
+          content-type        = "application/json"
+          x-resolved-identity = "clark.kent"
+        }
+        json_body = {
+          sub = "clark.kent"
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  beta_authz_external "authz" {
+    url = "http://127.0.0.1:8081/check"
+  }
+}


### PR DESCRIPTION
## Context

Exposes the authorization service's **response headers** as `request.context.<label>.headers` (lower-cased names, first value, like `request.headers`), alongside the JSON body already exposed at `request.context.<label>`.

This **replaces the earlier `allowed_upstream_headers` attribute** (which mutated the client request invisibly from the `definitions` block). Consumers now inject a resolved identity or a re-signed internal token upstream explicitly in the consuming endpoint:

```hcl
proxy {
  backend = "protected_api"
  set_request_headers = {
    x-resolved-identity = request.context.authz.headers["x-resolved-identity"]
  }
}
```

`set_request_headers` overwrites client-provided values, so the anti-spoofing guarantee is preserved — but it is now visible where it happens instead of an implicit allowlist. A body property literally named `headers` is shadowed by the response headers.

Predecessor: #974. Successor: #976. Part of the `beta_external_authz` stack (#874 → #974 → #975 → #976 → #977 → #978 → #979).

Assisted by [Claude Code](https://claude.ai/code)