### PR TITLE
beta_external_authz: HTTP/2 callout transport test + latency docs (4/8)

### DIFF
--- a/accesscontrol/authz/DESIGN.md
+++ b/accesscontrol/authz/DESIGN.md
@@ -58,13 +58,21 @@ Register error types for the new access control (compare `beta_mcp_tool_blocked`
 The 401/403 distinction is load-bearing for OAuth resources: `invalid_token` tells
 the client to (re)acquire a token; `insufficient_scope` tells it not to bother.
 
-### 4. Opt-in decision caching
+### 4. Callout latency — persistent HTTP/2, no gateway-side decision caching
 
 MCP (and JSON-RPC in general) funnels every operation through one `POST` endpoint, so
-a synchronous callout per request doubles request latency on the hottest path. Offer
-an opt-in TTL cache in the existing `cache.MemoryStore` keyed on a hash of the
-presented credential (never the raw value), analogous to the backend `oauth2` token
-cache in `handler/transport/oauth2_req_auth.go`.
+a synchronous callout per request doubles request latency on the hottest path.
+
+Decided against an opt-in decision cache in the gateway: a decision is a function of
+whatever the service looked at (credential, path, method, TLS state), which the gateway
+cannot know — the same reason Envoy's `ext_authz` never shipped result caching. The
+authorization service caches internally where its decision allows it.
+
+Instead the callout cost is reduced Envoy-style via connection reuse: a `backend` with
+`http2 = true` multiplexes all callouts over one persistent HTTP/2 (TLS/ALPN) connection
+to the — typically local — authorization service; without it, HTTP/1.1 keep-alive still
+avoids per-request connection setup. Cleartext h2c is not supported by the backend
+transport.
 
 ### 5. Keep request-body forwarding out of the initial scope
 

--- a/docs/website/content/configuration/block/beta_authz_external.md
+++ b/docs/website/content/configuration/block/beta_authz_external.md
@@ -50,9 +50,13 @@ With `include_tls = true` the TLS connection information of the client request i
 }
 ```
 
-Couper calls the authorization service on the hot path of every protected request. For a
-low-latency setup configure a `backend` with `http2 = true`: callouts are then multiplexed
-over a single persistent HTTP/2 connection to the (typically local) authorization service.
+Couper calls the authorization service on the hot path of every protected request, so the
+connection to it should be persistent. This is the recommended setup: a (typically local)
+authorization service behind a `backend` with `http2 = true` — callouts are then multiplexed
+over a single persistent HTTP/2 connection instead of paying a round trip per request.
+HTTP/2 is negotiated via TLS (ALPN), so the authorization service must be reachable via
+`https` — without `http2` Couper still reuses connections (HTTP/1.1 keep-alive), just
+without multiplexing.
 
 ```hcl
 definitions {
@@ -64,6 +68,10 @@ definitions {
   }
 }
 ```
+
+Couper does not cache authorization decisions: whether a decision may be reused is only
+known to the authorization service, which can cache internally whenever its decision
+allows it.
 
 The response status code of the authorization service determines the decision:
 

--- a/docs/website/content/configuration/block/beta_authz_external.md
+++ b/docs/website/content/configuration/block/beta_authz_external.md
@@ -50,6 +50,21 @@ With `include_tls = true` the TLS connection information of the client request i
 }
 ```
 
+Couper calls the authorization service on the hot path of every protected request. For a
+low-latency setup configure a `backend` with `http2 = true`: callouts are then multiplexed
+over a single persistent HTTP/2 connection to the (typically local) authorization service.
+
+```hcl
+definitions {
+  beta_authz_external "authz" {
+    backend {
+      origin = "https://localhost:4000"
+      http2  = true
+    }
+  }
+}
+```
+
 The response status code of the authorization service determines the decision:
 
 | Status    | Result                                                                                    |

--- a/server/http_authz_external_test.go
+++ b/server/http_authz_external_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/coupergateway/couper/internal/test"
@@ -126,6 +128,65 @@ func TestAuthzExternal_ResponseHeaders(t *testing.T) {
 	}
 	if evil := res.Header.Get("X-Evil"); evil != "" {
 		t.Errorf("expected no value for an unset callout header, got: %q", evil)
+	}
+}
+
+func TestAuthzExternal_HTTP2Callout(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	var mu sync.Mutex
+	var calloutProtos, calloutConns []string
+
+	authzService := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		calloutProtos = append(calloutProtos, req.Proto)
+		calloutConns = append(calloutConns, req.RemoteAddr)
+		mu.Unlock()
+
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(map[string]string{"proto": req.Proto})
+	}))
+	authzService.EnableHTTP2 = true
+	authzService.StartTLS()
+	defer authzService.Close()
+
+	shutdown, hook, err := newCouperWithTemplate("testdata/authz_external/05_couper.hcl", helper,
+		map[string]interface{}{"origin": authzService.URL})
+	helper.Must(err)
+	defer shutdown()
+	hook.Reset()
+
+	for range 2 {
+		req, rerr := http.NewRequest(http.MethodGet, "http://protected.local:8080/protected", nil)
+		helper.Must(rerr)
+
+		res, derr := client.Do(req)
+		helper.Must(derr)
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("expected status %d, got: %d", http.StatusOK, res.StatusCode)
+		}
+		if proto := res.Header.Get("X-Authz-Proto"); proto != "HTTP/2.0" {
+			t.Fatalf("expected authz context proto HTTP/2.0, got: %q", proto)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(calloutProtos) != 2 {
+		t.Fatalf("expected 2 callouts, got: %d", len(calloutProtos))
+	}
+	for _, proto := range calloutProtos {
+		if proto != "HTTP/2.0" {
+			t.Errorf("expected HTTP/2.0 callout, got: %q", proto)
+		}
+	}
+	if calloutConns[0] != calloutConns[1] {
+		t.Errorf("expected callouts to reuse one connection, got: %v", calloutConns)
 	}
 }
 

--- a/server/testdata/authz_external/05_couper.hcl
+++ b/server/testdata/authz_external/05_couper.hcl
@@ -1,0 +1,25 @@
+server "protected" {
+  hosts = ["*:8080"]
+
+  api {
+    endpoint "/protected" {
+      access_control = ["authz"]
+
+      response {
+        headers = {
+          x-authz-proto = request.context.authz.proto
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  beta_authz_external "authz" {
+    backend {
+      origin                         = "{{.origin}}"
+      http2                          = true
+      disable_certificate_validation = true
+    }
+  }
+}


### PR DESCRIPTION
refs #873 — stacked on #975 (part 4/5); successor: #977.

## Context

MCP funnels every operation through one POST endpoint, so a synchronous callout per request doubles latency on the hottest path (DESIGN.md §4). Gateway-side decision caching was considered and rejected: a decision is a function of whatever the service looked at, which the gateway cannot know — the same reason Envoy's `ext_authz` never shipped result caching. The authorization service caches internally where its decision allows it.

## This PR

- Integration test proving the Envoy-style alternative works: a `backend` with `http2 = true` negotiates HTTP/2 (TLS/ALPN) to a local authorization service and multiplexes sequential callouts over **one persistent connection** (asserted via protocol seen by the service and stable remote address)
- Docs: recommend the persistent h2 setup, note that h2 requires TLS (no h2c in the backend transport) and that HTTP/1.1 keep-alive still applies without it; DESIGN.md §4 updated to record the no-caching decision


Assisted by [Claude Code](https://claude.ai/code)

