### PR TITLE
beta_external_authz: permissions_property (5/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 * **Added**
   * `beta_authz_external` access control: delegate the authorization decision to an external service via an HTTP callout, with distinct `authz_external_invalid_credentials` (401) and `authz_external_insufficient_permissions` (403) error types and opt-in TLS connection metadata (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
   * expose a `beta_authz_external` callout's JSON object response body and its response headers (`request.context.<label>` / `request.context.<label>.headers`); inject a resolved identity upstream with `set_request_headers` ([#873](https://github.com/coupergateway/couper/issues/873))
+  * `permissions_claim` attribute for `beta_authz_external`: grant permissions for `required_permission` checks from a response body property of the authorization service ([#873](https://github.com/coupergateway/couper/issues/873))
 
 ---
 

--- a/accesscontrol/authz/external.go
+++ b/accesscontrol/authz/external.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/coupergateway/couper/config/request"
@@ -21,10 +23,11 @@ const roundTripName = "authz_external"
 // External authorization calls out to a service which decides whether the
 // client request is allowed: 200 allows, 401 and 403 map to distinct error types.
 type External struct {
-	includeTLS bool
-	name       string
-	transport  http.RoundTripper
-	url        string
+	includeTLS       bool
+	name             string
+	permissionsClaim string
+	transport        http.RoundTripper
+	url              string
 }
 
 // simplified form of http.Request for serialization
@@ -55,15 +58,16 @@ type authContext struct {
 	MetadataTLS   *metadataTLS  `json:"metadata_tls,omitempty"`
 }
 
-func NewExternal(name, calloutURL string, includeTLS bool, transport http.RoundTripper) *External {
+func NewExternal(name, calloutURL string, includeTLS bool, permissionsClaim string, transport http.RoundTripper) *External {
 	if calloutURL == "" { // destination origin is provided by the backend configuration
 		calloutURL = "/"
 	}
 	return &External{
-		includeTLS: includeTLS,
-		name:       name,
-		transport:  transport,
-		url:        calloutURL,
+		includeTLS:       includeTLS,
+		name:             name,
+		permissionsClaim: permissionsClaim,
+		transport:        transport,
+		url:              calloutURL,
 	}
 }
 
@@ -131,7 +135,12 @@ func (e *External) Validate(req *http.Request) error {
 
 	switch res.StatusCode {
 	case http.StatusOK:
-		return e.storeContext(req, res)
+		data, derr := e.parseResponseBody(res)
+		if derr != nil {
+			return derr
+		}
+		e.storeContext(req, withResponseHeaders(data, res.Header))
+		return e.grantPermissions(req, data)
 	case http.StatusUnauthorized:
 		return errors.AuthzExternalInvalidCredentials.Label(e.name).Message("invalid credentials")
 	case http.StatusForbidden:
@@ -141,34 +150,36 @@ func (e *External) Validate(req *http.Request) error {
 	}
 }
 
-// storeContext exposes the callout response as request.context.<label>: the properties of a
-// JSON object response body, plus the response headers under a "headers" property (lower-cased
-// names, first value, matching request.headers). Consumers inject a resolved identity or a
-// re-signed internal token upstream by reading these and writing set_request_headers, which
-// overwrites client-provided values. A malformed JSON body denies the request, as downstream
-// permission checks may rely on it. A body property literally named "headers" is shadowed by
-// the response headers.
-func (e *External) storeContext(req *http.Request, res *http.Response) error {
-	data := map[string]interface{}{}
-
+// parseResponseBody reads a JSON object response body. A malformed body denies
+// the request: silently dropping data which downstream permission checks may
+// rely on would fail open.
+func (e *External) parseResponseBody(res *http.Response) (map[string]interface{}, error) {
 	mediaType, _, _ := mime.ParseMediaType(res.Header.Get("Content-Type"))
-	if mediaType == "application/json" {
-		raw, err := io.ReadAll(res.Body)
-		if err != nil {
-			return errors.AuthzExternal.Label(e.name).With(err)
-		}
-		if len(raw) > 0 {
-			var body map[string]interface{}
-			if err = json.Unmarshal(raw, &body); err != nil {
-				return errors.AuthzExternal.Label(e.name).Message("unexpected authorization service response body").With(err)
-			}
-			for name, value := range body {
-				data[name] = value
-			}
-		}
+	if mediaType != "application/json" {
+		return nil, nil
 	}
 
-	data["headers"] = seetie.HeaderToMap(res.Header)
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.AuthzExternal.Label(e.name).With(err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	var data map[string]interface{}
+	if err = json.Unmarshal(raw, &data); err != nil {
+		return nil, errors.AuthzExternal.Label(e.name).Message("unexpected authorization service response body").With(err)
+	}
+
+	return data, nil
+}
+
+// storeContext exposes the response data as request.context.<label>.
+func (e *External) storeContext(req *http.Request, data map[string]interface{}) {
+	if data == nil {
+		return
+	}
 
 	ctx := req.Context()
 	acMap, ok := ctx.Value(request.AccessControls).(map[string]interface{})
@@ -177,6 +188,64 @@ func (e *External) storeContext(req *http.Request, res *http.Response) error {
 	}
 	acMap[e.name] = data
 	*req = *req.WithContext(context.WithValue(ctx, request.AccessControls, acMap))
+}
+
+// withResponseHeaders adds the callout response headers to the context data under "headers"
+// (lower-cased names, first value, like request.headers), without polluting the body map used
+// for permissions. A body property literally named "headers" is shadowed.
+func withResponseHeaders(data map[string]interface{}, header http.Header) map[string]interface{} {
+	ctx := map[string]interface{}{}
+	for name, value := range data {
+		ctx[name] = value
+	}
+	ctx["headers"] = seetie.HeaderToMap(header)
+	return ctx
+}
+
+// grantPermissions appends the permissions from the configured response body
+// property to the request's granted permissions with the same value semantics
+// as the jwt permissions_claim: a space-separated string or a list of strings.
+func (e *External) grantPermissions(req *http.Request, data map[string]interface{}) error {
+	if e.permissionsClaim == "" {
+		return nil
+	}
+
+	value, exists := data[e.permissionsClaim]
+	if !exists {
+		return nil
+	}
+
+	invalidErr := func() error {
+		return errors.AuthzExternal.Label(e.name).
+			Messagef("invalid %s permissions value: %#v", e.permissionsClaim, value)
+	}
+
+	var permissions []string
+	switch v := value.(type) {
+	case string:
+		permissions = strings.Split(v, " ")
+	case []interface{}:
+		for _, entry := range v {
+			p, ok := entry.(string)
+			if !ok {
+				return invalidErr()
+			}
+			permissions = append(permissions, p)
+		}
+	default:
+		return invalidErr()
+	}
+
+	ctx := req.Context()
+	granted, _ := ctx.Value(request.GrantedPermissions).([]string)
+	for _, p := range permissions {
+		p = strings.TrimSpace(p)
+		if p == "" || slices.Contains(granted, p) {
+			continue
+		}
+		granted = append(granted, p)
+	}
+	*req = *req.WithContext(context.WithValue(ctx, request.GrantedPermissions, granted))
 
 	return nil
 }

--- a/accesscontrol/authz/external_test.go
+++ b/accesscontrol/authz/external_test.go
@@ -1,6 +1,7 @@
 package authz_test
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -43,7 +44,7 @@ func TestExternal_Validate_Status(t *testing.T) {
 		{"deny on unexpected status", http.StatusBadGateway, "authz_external"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			external := authz.NewExternal("test_ac", "http://authz.service/check", false, respondStatus(tc.status))
+			external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", respondStatus(tc.status))
 
 			req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
 			err := external.Validate(req)
@@ -78,7 +79,7 @@ func TestExternal_Validate_CalloutRequest(t *testing.T) {
 		return respondStatus(http.StatusOK)(req)
 	})
 
-	external := authz.NewExternal("test_ac", "http://authz.service/check", false, transport)
+	external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", transport)
 
 	req := httptest.NewRequest(http.MethodDelete, "http://client.request/protected?a=b", nil)
 	req.Header.Set("Authorization", "Bearer my-token")
@@ -138,7 +139,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 	}
 
 	t.Run("json object response lands in access control context", func(t *testing.T) {
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "",
 			respondBody("application/json", `{"sub":"clark.kent","roles":["reporter"]}`))
 
 		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
@@ -160,7 +161,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 	})
 
 	t.Run("response headers are exposed under headers", func(t *testing.T) {
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "",
 			roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
 				rec := httptest.NewRecorder()
 				rec.Header().Set("Content-Type", "application/json")
@@ -182,7 +183,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 	})
 
 	t.Run("invalid json fails closed", func(t *testing.T) {
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "",
 			respondBody("application/json", `{"sub":`))
 
 		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
@@ -198,7 +199,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 	})
 
 	t.Run("non-object json fails closed", func(t *testing.T) {
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "",
 			respondBody("application/json", `[1,2]`))
 
 		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
@@ -208,7 +209,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 	})
 
 	t.Run("empty body still exposes headers", func(t *testing.T) {
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "",
 			respondBody("application/json", ""))
 
 		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
@@ -221,7 +222,7 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 	})
 
 	t.Run("non-json response exposes headers without body properties", func(t *testing.T) {
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false,
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "",
 			respondBody("text/plain", "OK"))
 
 		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
@@ -234,6 +235,93 @@ func TestExternal_Validate_ContextPropagation(t *testing.T) {
 		}
 		if data["sub"] != nil {
 			t.Errorf("expected no body properties, got: %v", data)
+		}
+	})
+}
+
+func TestExternal_Validate_PermissionsClaim(t *testing.T) {
+	respondJSON := func(body string) roundTripperFunc {
+		return func(_ *http.Request) (*http.Response, error) {
+			rec := httptest.NewRecorder()
+			rec.Header().Set("Content-Type", "application/json")
+			rec.WriteHeader(http.StatusOK)
+			_, _ = rec.WriteString(body)
+			return rec.Result(), nil
+		}
+	}
+
+	granted := func(req *http.Request) []string {
+		permissions, _ := req.Context().Value(request.GrantedPermissions).([]string)
+		return permissions
+	}
+
+	newExternal := func(body string) *authz.External {
+		return authz.NewExternal("test_ac", "http://authz.service/check", false, "perms", respondJSON(body))
+	}
+
+	t.Run("list property grants permissions", func(t *testing.T) {
+		external := newExternal(`{"perms":["read","write"]}`)
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if p := granted(req); len(p) != 2 || p[0] != "read" || p[1] != "write" {
+			t.Errorf("unexpected granted permissions: %v", p)
+		}
+	})
+
+	t.Run("space-separated string grants permissions", func(t *testing.T) {
+		external := newExternal(`{"perms":"read write"}`)
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if p := granted(req); len(p) != 2 || p[0] != "read" || p[1] != "write" {
+			t.Errorf("unexpected granted permissions: %v", p)
+		}
+	})
+
+	t.Run("appends to and dedupes against already granted permissions", func(t *testing.T) {
+		external := newExternal(`{"perms":["read","write"]}`)
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		ctx := context.WithValue(req.Context(), request.GrantedPermissions, []string{"admin", "read"})
+		req = req.WithContext(ctx)
+
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if p := granted(req); len(p) != 3 || p[0] != "admin" || p[1] != "read" || p[2] != "write" {
+			t.Errorf("unexpected granted permissions: %v", p)
+		}
+	})
+
+	t.Run("missing property grants nothing", func(t *testing.T) {
+		external := newExternal(`{"sub":"clark.kent"}`)
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if p := granted(req); len(p) != 0 {
+			t.Errorf("expected no granted permissions, got: %v", p)
+		}
+	})
+
+	t.Run("invalid property type fails closed", func(t *testing.T) {
+		for _, body := range []string{`{"perms":42}`, `{"perms":["read",42]}`} {
+			external := newExternal(body)
+			req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+
+			err := external.Validate(req)
+			cErr, ok := err.(*errors.Error)
+			if !ok {
+				t.Fatalf("expected *errors.Error for %s, got: %T", body, err)
+			}
+			if kinds := cErr.Kinds(); len(kinds) == 0 || kinds[0] != "authz_external" {
+				t.Errorf("expected error kind authz_external for %s, got: %v", body, kinds)
+			}
 		}
 	})
 }
@@ -264,7 +352,7 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 
 	t.Run("enabled", func(t *testing.T) {
 		var calloutBody []byte
-		external := authz.NewExternal("test_ac", "http://authz.service/check", true, captureBody(&calloutBody))
+		external := authz.NewExternal("test_ac", "http://authz.service/check", true, "", captureBody(&calloutBody))
 
 		if err := external.Validate(newTLSRequest()); err != nil {
 			t.Fatalf("expected no error, got: %v", err)
@@ -302,7 +390,7 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 
 	t.Run("enabled without tls connection", func(t *testing.T) {
 		var calloutBody []byte
-		external := authz.NewExternal("test_ac", "http://authz.service/check", true, captureBody(&calloutBody))
+		external := authz.NewExternal("test_ac", "http://authz.service/check", true, "", captureBody(&calloutBody))
 
 		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
 		if err := external.Validate(req); err != nil {
@@ -320,7 +408,7 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 
 	t.Run("disabled", func(t *testing.T) {
 		var calloutBody []byte
-		external := authz.NewExternal("test_ac", "http://authz.service/check", false, captureBody(&calloutBody))
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", captureBody(&calloutBody))
 
 		if err := external.Validate(newTLSRequest()); err != nil {
 			t.Fatalf("expected no error, got: %v", err)
@@ -337,7 +425,7 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 }
 
 func TestExternal_Validate_TransportError(t *testing.T) {
-	external := authz.NewExternal("test_ac", "http://authz.service/check", false, roundTripperFunc(
+	external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", roundTripperFunc(
 		func(_ *http.Request) (*http.Response, error) {
 			return nil, io.ErrUnexpectedEOF
 		}))
@@ -356,7 +444,7 @@ func TestExternal_Validate_TransportError(t *testing.T) {
 
 func TestExternal_Validate_EmptyURL(t *testing.T) {
 	var calloutURL string
-	external := authz.NewExternal("test_ac", "", false, roundTripperFunc(
+	external := authz.NewExternal("test_ac", "", false, "", roundTripperFunc(
 		func(req *http.Request) (*http.Response, error) {
 			calloutURL = req.URL.String()
 			return respondStatus(http.StatusOK)(req)

--- a/config/ac_authz_external.go
+++ b/config/ac_authz_external.go
@@ -21,11 +21,12 @@ var (
 // AuthZExternal represents the beta_authz_external block.
 type AuthZExternal struct {
 	ErrorHandlerSetter
-	BackendName string   `hcl:"backend,optional" docs:"References a [backend](/configuration/block/backend) in [definitions](/configuration/block/definitions) for the authorization callout. Mutually exclusive with {backend} block."`
-	IncludeTLS  bool     `hcl:"include_tls,optional" docs:"Include TLS connection information of the client request in the authorization request." default:"false"`
-	Name        string   `hcl:"name,label"`
-	URL         string   `hcl:"url,optional" docs:"URL of the authorization service. Relative URL references are resolved against the origin of a referenced or nested {backend} block."`
-	Remain      hcl.Body `hcl:",remain"`
+	BackendName      string   `hcl:"backend,optional" docs:"References a [backend](/configuration/block/backend) in [definitions](/configuration/block/definitions) for the authorization callout. Mutually exclusive with {backend} block."`
+	IncludeTLS       bool     `hcl:"include_tls,optional" docs:"Include TLS connection information of the client request in the authorization request." default:"false"`
+	Name             string   `hcl:"name,label"`
+	PermissionsClaim string   `hcl:"permissions_claim,optional" docs:"Name of the response body property containing the granted permissions. The property value must either be a string containing a space-separated list of permissions or a list of string permissions."`
+	URL              string   `hcl:"url,optional" docs:"URL of the authorization service. Relative URL references are resolved against the origin of a referenced or nested {backend} block."`
+	Remain           hcl.Body `hcl:",remain"`
 
 	// Internally used
 	Backend *hclsyntax.Body

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -534,7 +534,8 @@ func configureAccessControls(conf *config.Couper, confCtx *hcl.EvalContext, log 
 				return nil, confErr.With(err)
 			}
 
-			authZExt := authz.NewExternal(authZExternal.Name, authZExternal.URL, authZExternal.IncludeTLS, backend)
+			authZExt := authz.NewExternal(authZExternal.Name, authZExternal.URL, authZExternal.IncludeTLS,
+				authZExternal.PermissionsClaim, backend)
 			accessControls.Add(authZExternal.Name, authZExt, authZExternal.ErrorHandler)
 		}
 

--- a/docs/website/content/configuration/block/beta_authz_external.md
+++ b/docs/website/content/configuration/block/beta_authz_external.md
@@ -110,6 +110,21 @@ api {
 }
 ```
 
+
+With `permissions_claim` the authorization service can grant [permissions](/configuration/error-handling#permissions-related-error_handler)
+evaluated by `required_permission` in [`api`](/configuration/block/api) or [`endpoint`](/configuration/block/endpoint)
+blocks: the named response body property — a space-separated string or a list of strings, like the
+[`jwt` block's](/configuration/block/jwt) `permissions_claim` — is added to `request.context.granted_permissions`.
+
+```hcl
+definitions {
+  beta_authz_external "authz" {
+    url               = "https://authz.example.com/check"
+    permissions_claim = "granted_permissions"
+  }
+}
+```
+
 The error types can be handled with [`error_handler` blocks](/configuration/error-handling),
 for example to send a `WWW-Authenticate` challenge pointing OAuth 2.0 clients to the
 protected resource metadata (RFC 9728).
@@ -147,6 +162,12 @@ definitions {
     "description": "Include TLS connection information of the client request in the authorization request.",
     "name": "include_tls",
     "type": "bool"
+  },
+  {
+    "default": "",
+    "description": "Name of the response body property containing the granted permissions. The property value must either be a string containing a space-separated list of permissions or a list of string permissions.",
+    "name": "permissions_claim",
+    "type": "string"
   },
   {
     "default": "",

--- a/server/http_authz_external_test.go
+++ b/server/http_authz_external_test.go
@@ -190,6 +190,55 @@ func TestAuthzExternal_HTTP2Callout(t *testing.T) {
 	}
 }
 
+func TestAuthzExternal_PermissionsClaim(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	shutdown, hook := newCouper("testdata/authz_external/06_couper.hcl", helper)
+	defer shutdown()
+
+	for _, tc := range []struct {
+		name          string
+		authorization string
+		expStatus     int
+		expErrorType  string
+	}{
+		{"granted permission", "Bearer reader", http.StatusNoContent, ""},
+		{"missing permission", "Bearer nobody", http.StatusForbidden, "insufficient_permissions"},
+	} {
+		t.Run(tc.name, func(st *testing.T) {
+			hook.Reset()
+
+			req, err := http.NewRequest(http.MethodGet, "http://protected.local:8080/protected", nil)
+			helper.Must(err)
+			req.Header.Set("Authorization", tc.authorization)
+
+			res, err := client.Do(req)
+			helper.Must(err)
+			_, _ = io.Copy(io.Discard, res.Body)
+			_ = res.Body.Close()
+
+			if res.StatusCode != tc.expStatus {
+				st.Errorf("expected status %d, got: %d", tc.expStatus, res.StatusCode)
+			}
+
+			if tc.expErrorType == "" {
+				return
+			}
+
+			var loggedType string
+			for _, entry := range hook.AllEntries() {
+				if errorType, ok := entry.Data["error_type"].(string); ok && entry.Data["port"] == "8080" {
+					loggedType = errorType
+				}
+			}
+			if loggedType != tc.expErrorType {
+				st.Errorf("expected logged error_type %q, got: %q", tc.expErrorType, loggedType)
+			}
+		})
+	}
+}
+
 func TestAuthzExternal_ErrorHandler(t *testing.T) {
 	client := newClient()
 	helper := test.New(t)

--- a/server/testdata/authz_external/06_couper.hcl
+++ b/server/testdata/authz_external/06_couper.hcl
@@ -1,0 +1,35 @@
+server "protected" {
+  hosts = ["*:8080"]
+
+  api {
+    endpoint "/protected" {
+      access_control      = ["authz"]
+      required_permission = "can_read"
+
+      response {
+        status = 204
+      }
+    }
+  }
+}
+
+server "authz-service" {
+  hosts = ["*:8081"]
+
+  api {
+    endpoint "/check" {
+      response {
+        json_body = {
+          granted_permissions = lookup(request.json_body.client_request.headers, "Authorization", [""])[0] == "Bearer reader" ? ["can_read", "can_list"] : ["can_list"]
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  beta_authz_external "authz" {
+    url               = "http://127.0.0.1:8081/check"
+    permissions_claim = "granted_permissions"
+  }
+}


### PR DESCRIPTION
refs #873 — stacked on #976, merge last (part 5/5).

## Context

`required_permission` checks read `request.GrantedPermissions`, which only the `jwt` access control populates. When `beta_authz_external` replaces a `jwt` block, the callout's authorization data must feed the same mechanism — otherwise permission-gated endpoints cannot be protected by the callout (DESIGN.md §1).

## This PR

- `permissions_claim` attribute names a response body property of the authorization service; its value is appended to the request's granted permissions
- Same value semantics as the `jwt` block's `permissions_claim`: a space-separated string or a list of strings, deduplicated
- Appending (not replacing) composes with a chained `jwt` access control in the same `access_control` list
- Missing property grants nothing; a wrongly-typed property denies the request (fail closed)
- Everything downstream works unchanged: `required_permission`, the `insufficient_permissions` error type, `request.context.granted_permissions`
- Unit tests + end-to-end integration test (`required_permission` grant/deny), docs, CHANGELOG


Assisted by [Claude Code](https://claude.ai/code)