### PR TITLE
beta_external_authz: cleartext HTTP/2 callouts + protocol logging (7/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Added**
   * `beta_external_authz` access control: delegate the authorization decision to an external service via an HTTP callout, with distinct `external_authz_invalid_credentials` (401) and `external_authz_insufficient_permissions` (403) error types and opt-in TLS connection metadata (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
+  * `http2_prior_knowledge` backend attribute: cleartext HTTP/2 (h2c) for trusted `http` origins, e.g. multiplexed `beta_external_authz` callouts without TLS ([#873](https://github.com/coupergateway/couper/issues/873))
   * forward the authorization service's `WWW-Authenticate` challenge on `beta_external_authz` denials via a default `error_handler`; the value is available as `request.context.<label>.www_authenticate` ([#873](https://github.com/coupergateway/couper/issues/873))
   * expose a `beta_external_authz` callout's JSON object response body and its response headers (`request.context.<label>` / `request.context.<label>.headers`); inject a resolved identity upstream with `set_request_headers` ([#873](https://github.com/coupergateway/couper/issues/873))
   * `permissions_property` attribute for `beta_external_authz`: grant permissions for `required_permission` checks from a named response body property of the authorization service; a configured property missing from a `200` response denies the request ([#873](https://github.com/coupergateway/couper/issues/873))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Added**
   * `beta_external_authz` access control: delegate the authorization decision to an external service via an HTTP callout, with distinct `external_authz_invalid_credentials` (401) and `external_authz_insufficient_permissions` (403) error types and opt-in TLS connection metadata (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
+  * log the negotiated HTTP protocol version of backend responses (`response.proto` in `couper_backend` logs) ([#873](https://github.com/coupergateway/couper/issues/873))
   * `http2_prior_knowledge` backend attribute: cleartext HTTP/2 (h2c) for trusted `http` origins, e.g. multiplexed `beta_external_authz` callouts without TLS ([#873](https://github.com/coupergateway/couper/issues/873))
   * forward the authorization service's `WWW-Authenticate` challenge on `beta_external_authz` denials via a default `error_handler`; the value is available as `request.context.<label>.www_authenticate` ([#873](https://github.com/coupergateway/couper/issues/873))
   * expose a `beta_external_authz` callout's JSON object response body and its response headers (`request.context.<label>` / `request.context.<label>.headers`); inject a resolved identity upstream with `set_request_headers` ([#873](https://github.com/coupergateway/couper/issues/873))

--- a/config/backend.go
+++ b/config/backend.go
@@ -19,7 +19,8 @@ type Backend struct {
 	DisableCertValidation  bool        `hcl:"disable_certificate_validation,optional" docs:"Disables the peer certificate validation. Must not be used in backend refinement."`
 	DisableConnectionReuse bool        `hcl:"disable_connection_reuse,optional" docs:"Disables reusage of connections to the origin. Must not be used in backend refinement."`
 	Health                 *Health     `hcl:"beta_health,block" docs:"Configures a [health check](/configuration/block/health) (zero or one)."`
-	HTTP2                  bool        `hcl:"http2,optional" docs:"Enables the HTTP2 support. Must not be used in backend refinement."`
+	HTTP2                  bool        `hcl:"http2,optional" docs:"Enables the HTTP2 support. HTTP2 is negotiated during the TLS handshake (ALPN), so it applies to {https} origins only. Must not be used in backend refinement."`
+	HTTP2PriorKnowledge    bool        `hcl:"http2_prior_knowledge,optional" docs:"Uses cleartext HTTP2 (h2c) with prior knowledge for {http} origins — the origin must speak HTTP2. Must not be used in backend refinement."`
 	MaxConnections         int         `hcl:"max_connections,optional" docs:"The maximum number of concurrent connections in any state (_active_ or _idle_) to the origin. Must not be used in backend refinement." default:"0"`
 	Name                   string      `hcl:"name,label_optional"`
 	OpenAPI                *OpenAPI    `hcl:"openapi,block" docs:"Configures [OpenAPI validation](/configuration/block/openapi) (zero or one)."`

--- a/config/configload/validate.go
+++ b/config/configload/validate.go
@@ -276,7 +276,7 @@ func verifyResponseBodyAttrs(b *hclsyntax.Body) error {
 	return nil
 }
 
-var invalidAttributes = []string{"disable_certificate_validation", "disable_connection_reuse", "http2", "max_connections"}
+var invalidAttributes = []string{"disable_certificate_validation", "disable_connection_reuse", "http2", "http2_prior_knowledge", "max_connections"}
 
 func invalidRefinement(body *hclsyntax.Body) error {
 	const message = "backend reference: refinement for %q is not permitted"

--- a/config/runtime/backend.go
+++ b/config/runtime/backend.go
@@ -73,6 +73,7 @@ func newBackend(evalCtx *hcl.EvalContext, backendCtx *hclsyntax.Body, log *logru
 		DisableCertValidation:  beConf.DisableCertValidation,
 		DisableConnectionReuse: beConf.DisableConnectionReuse,
 		HTTP2:                  beConf.HTTP2,
+		HTTP2PriorKnowledge:    beConf.HTTP2PriorKnowledge,
 		NoProxyFromEnv:         conf.Settings.NoProxyFromEnv,
 		MaxConnections:         beConf.MaxConnections,
 	}

--- a/docs/website/content/configuration/block/backend.md
+++ b/docs/website/content/configuration/block/backend.md
@@ -79,8 +79,14 @@ Backends can be defined in the [Definitions Block](/configuration/block/definiti
   },
   {
     "default": "false",
-    "description": "Enables the HTTP2 support. Must not be used in backend refinement.",
+    "description": "Enables the HTTP2 support. HTTP2 is negotiated during the TLS handshake (ALPN), so it applies to `https` origins only. Must not be used in backend refinement.",
     "name": "http2",
+    "type": "bool"
+  },
+  {
+    "default": "false",
+    "description": "Uses cleartext HTTP2 (h2c) with prior knowledge for `http` origins — the origin must speak HTTP2. Must not be used in backend refinement.",
+    "name": "http2_prior_knowledge",
     "type": "bool"
   },
   {

--- a/docs/website/content/configuration/block/beta_external_authz.md
+++ b/docs/website/content/configuration/block/beta_external_authz.md
@@ -54,9 +54,11 @@ Couper calls the authorization service on the hot path of every protected reques
 connection to it should be persistent. This is the recommended setup: a (typically local)
 authorization service behind a `backend` with `http2 = true` — callouts are then multiplexed
 over a single persistent HTTP/2 connection instead of paying a round trip per request.
-HTTP/2 is negotiated via TLS (ALPN), so the authorization service must be reachable via
-`https` — without `http2` Couper still reuses connections (HTTP/1.1 keep-alive), just
-without multiplexing.
+HTTP/2 is negotiated via TLS (ALPN), so `http2` applies to `https` origins. For a trusted
+cleartext (`http`) authorization service, `http2_prior_knowledge = true` establishes the
+same multiplexed HTTP/2 connection without TLS (h2c) — the service must speak HTTP/2.
+Without either, Couper still reuses connections (HTTP/1.1 keep-alive), just without
+multiplexing.
 
 ```hcl
 definitions {

--- a/handler/transport/transport.go
+++ b/handler/transport/transport.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coupergateway/couper/handler/throttle"
 	coupertls "github.com/coupergateway/couper/internal/tls"
 	"golang.org/x/net/http/httpproxy"
+	"golang.org/x/net/http2"
 )
 
 // Config represents the transport <Config> object.
@@ -25,6 +26,7 @@ type Config struct {
 	DisableCertValidation  bool
 	DisableConnectionReuse bool
 	HTTP2                  bool
+	HTTP2PriorKnowledge    bool
 	MaxConnections         int
 	NoProxyFromEnv         bool
 	Proxy                  string
@@ -49,8 +51,8 @@ type Config struct {
 	Scheme   string
 }
 
-// NewTransport creates a new <*http.Transport> object by the given <*Config>.
-func NewTransport(conf *Config, log *logrus.Entry) *http.Transport {
+// NewTransport creates the backend roundtripper for the given <*Config>.
+func NewTransport(conf *Config, log *logrus.Entry) http.RoundTripper {
 	tlsConf := coupertls.DefaultTLSConfig()
 	if len(conf.Certificate) > 0 {
 		tlsConf.RootCAs.AppendCertsFromPEM(conf.Certificate)
@@ -101,33 +103,58 @@ func NewTransport(conf *Config, log *logrus.Entry) *http.Transport {
 
 	logEntry := log.WithField("type", "couper_connection")
 
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		address := addr
+		if proxyFunc == nil {
+			address = conf.Origin
+		} // Otherwise, proxy connect will use this dial method and addr could be a proxy one.
+
+		connectTimeout, _ := ctx.Value(request.ConnectTimeout).(time.Duration)
+		if connectTimeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithDeadline(ctx, time.Now().Add(connectTimeout))
+			defer cancel()
+		}
+
+		conn, cerr := d.DialContext(ctx, network, address)
+		if cerr != nil {
+			host, port, _ := net.SplitHostPort(conf.Origin)
+			if port != "80" && port != "443" {
+				host = conf.Origin
+			}
+			if os.IsTimeout(cerr) || cerr == context.DeadlineExceeded {
+				return nil, fmt.Errorf("connecting to %s '%s' failed: i/o timeout", conf.BackendName, host)
+			}
+			return nil, fmt.Errorf("connecting to %s '%s' failed: %w", conf.BackendName, conf.Origin, cerr)
+		}
+		return NewOriginConn(ctx, conn, conf, logEntry), nil
+	}
+
+	// http2.Transport cannot dial through HTTP proxies; only skip the standard
+	// transport when no proxy applies to this origin.
+	proxied := false
+	if proxyFunc != nil {
+		if proxyReq, _ := http.NewRequest(http.MethodGet, conf.Scheme+"://"+conf.Origin, nil); proxyReq != nil {
+			proxyURL, _ := proxyFunc(proxyReq)
+			proxied = proxyURL != nil
+		}
+	}
+
+	if conf.HTTP2PriorKnowledge && conf.Scheme == "http" && !proxied {
+		// Cleartext HTTP/2 (h2c) with prior knowledge: the standard transport only
+		// negotiates h2 during the TLS handshake (ALPN), so plain-http origins —
+		// e.g. trusted in-cluster authorization callouts — need the explicit opt-in.
+		return &http2.Transport{
+			AllowHTTP:          true,
+			DisableCompression: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return dial(ctx, network, addr)
+			},
+		}
+	}
+
 	transport := &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			address := addr
-			if proxyFunc == nil {
-				address = conf.Origin
-			} // Otherwise, proxy connect will use this dial method and addr could be a proxy one.
-
-			connectTimeout, _ := ctx.Value(request.ConnectTimeout).(time.Duration)
-			if connectTimeout > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(connectTimeout))
-				defer cancel()
-			}
-
-			conn, cerr := d.DialContext(ctx, network, address)
-			if cerr != nil {
-				host, port, _ := net.SplitHostPort(conf.Origin)
-				if port != "80" && port != "443" {
-					host = conf.Origin
-				}
-				if os.IsTimeout(cerr) || cerr == context.DeadlineExceeded {
-					return nil, fmt.Errorf("connecting to %s '%s' failed: i/o timeout", conf.BackendName, host)
-				}
-				return nil, fmt.Errorf("connecting to %s '%s' failed: %w", conf.BackendName, conf.Origin, cerr)
-			}
-			return NewOriginConn(ctx, conn, conf, logEntry), nil
-		},
+		DialContext:        dial,
 		DisableCompression: true,
 		DisableKeepAlives:  conf.DisableConnectionReuse,
 		ForceAttemptHTTP2:  conf.HTTP2,

--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -150,6 +150,11 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 			"headers": filterHeader(u.config.ResponseHeaders, beresp.Header),
 			"status":  beresp.StatusCode,
 		}
+		// The request "proto" field carries the scheme; the negotiated protocol
+		// version (HTTP/1.1 vs HTTP/2.0) is otherwise invisible in the logs.
+		if beresp.Proto != "" {
+			responseFields["proto"] = beresp.Proto
+		}
 		fields["response"] = responseFields
 	}
 

--- a/server/http_external_authz_test.go
+++ b/server/http_external_authz_test.go
@@ -1,14 +1,20 @@
 package server_test
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 
 	"github.com/coupergateway/couper/internal/test"
+	"github.com/coupergateway/couper/server"
 )
 
 func TestExternalAuthz_Callout(t *testing.T) {
@@ -147,12 +153,15 @@ func TestExternalAuthz_HTTP2Callout(t *testing.T) {
 		rw.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(rw).Encode(map[string]string{"proto": req.Proto})
 	}))
+	selfSigned, err := server.NewCertificate(time.Minute, nil, nil)
+	helper.Must(err)
+	authzService.TLS = &tls.Config{Certificates: []tls.Certificate{*selfSigned.Server}}
 	authzService.EnableHTTP2 = true
 	authzService.StartTLS()
 	defer authzService.Close()
 
 	shutdown, hook, err := newCouperWithTemplate("testdata/external_authz/05_couper.hcl", helper,
-		map[string]interface{}{"origin": authzService.URL})
+		map[string]interface{}{"origin": authzService.URL, "ca": string(selfSigned.CACertificate.Certificate)})
 	helper.Must(err)
 	defer shutdown()
 	hook.Reset()
@@ -236,6 +245,64 @@ func TestExternalAuthz_PermissionsClaim(t *testing.T) {
 				st.Errorf("expected logged error_type %q, got: %q", tc.expErrorType, loggedType)
 			}
 		})
+	}
+}
+
+func TestExternalAuthz_H2CCallout(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	var mu sync.Mutex
+	var calloutProtos, calloutConns []string
+
+	h2s := &http2.Server{}
+	authzService := httptest.NewServer(h2c.NewHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		calloutProtos = append(calloutProtos, req.Proto)
+		calloutConns = append(calloutConns, req.RemoteAddr)
+		mu.Unlock()
+
+		rw.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(rw).Encode(map[string]string{"proto": req.Proto})
+	}), h2s))
+	defer authzService.Close()
+
+	shutdown, hook, err := newCouperWithTemplate("testdata/external_authz/08_couper.hcl", helper,
+		map[string]interface{}{"origin": authzService.URL})
+	helper.Must(err)
+	defer shutdown()
+	hook.Reset()
+
+	for range 2 {
+		req, rerr := http.NewRequest(http.MethodGet, "http://protected.local:8080/protected", nil)
+		helper.Must(rerr)
+
+		res, derr := client.Do(req)
+		helper.Must(derr)
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("expected status %d, got: %d", http.StatusOK, res.StatusCode)
+		}
+		if proto := res.Header.Get("X-Authz-Proto"); proto != "HTTP/2.0" {
+			t.Fatalf("expected authz context proto HTTP/2.0, got: %q", proto)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(calloutProtos) != 2 {
+		t.Fatalf("expected 2 callouts, got: %d", len(calloutProtos))
+	}
+	for _, proto := range calloutProtos {
+		if proto != "HTTP/2.0" {
+			t.Errorf("expected HTTP/2.0 cleartext callout, got: %q", proto)
+		}
+	}
+	if calloutConns[0] != calloutConns[1] {
+		t.Errorf("expected callouts to reuse one connection, got: %v", calloutConns)
 	}
 }
 

--- a/server/testdata/external_authz/08_couper.hcl
+++ b/server/testdata/external_authz/08_couper.hcl
@@ -17,14 +17,8 @@ server "protected" {
 definitions {
   beta_external_authz "authz" {
     backend {
-      origin = "{{.origin}}"
-      http2  = true
-
-      tls {
-        server_ca_certificate = <<-EOC
-{{ .ca }}
-EOC
-      }
+      origin                = "{{.origin}}"
+      http2_prior_knowledge = true
     }
   }
 }


### PR DESCRIPTION
## Context

Transport refinements enabling the documented "persistent HTTP/2 callout connection" for cleartext origins, and making the negotiated protocol observable. Stacks on 6/7 (#978).

Two commits:

1. **`http2_prior_knowledge` backend attribute** — `http2 = true` maps to Go's `ForceAttemptHTTP2`, which negotiates h2 **only via TLS ALPN**; a plain-`http` origin with `http2 = true` silently ran HTTP/1.1. The new opt-in uses `x/net/http2.Transport` with `AllowHTTP` (h2c prior knowledge) — the recommended multiplexed `beta_external_authz` callout without TLS, e.g. a trusted in-cluster service. Kept separate from `http2` so existing configs on h1-only cleartext origins don't break; proxied origins keep the standard transport (`http2.Transport` can't dial through proxies). The TLS/ALPN e2e test now validates a real self-signed CA chain instead of `disable_certificate_validation`.
2. **Log the negotiated protocol** of backend responses (`response.proto` in `couper_backend` logs) — the request `proto` field is the scheme, so h2 misconfigurations degraded to HTTP/1.1 with no signal in the logs.

Both verified end-to-end (h2c and ALPN h2), full suite green.

Assisted by [Claude Code](https://claude.ai/code)