### PR TITLE
beta_external_authz: client certificate identity in mTLS metadata (8/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
   * forward the authorization service's `WWW-Authenticate` challenge on `beta_external_authz` denials via a default `error_handler`; the value is available as `request.context.<label>.www_authenticate` ([#873](https://github.com/coupergateway/couper/issues/873))
   * expose a `beta_external_authz` callout's JSON object response body and its response headers (`request.context.<label>` / `request.context.<label>.headers`); inject a resolved identity upstream with `set_request_headers` ([#873](https://github.com/coupergateway/couper/issues/873))
   * `permissions_property` attribute for `beta_external_authz`: grant permissions for `required_permission` checks from a named response body property of the authorization service; a configured property missing from a `200` response denies the request ([#873](https://github.com/coupergateway/couper/issues/873))
+  * forward the client certificate identity in a `beta_external_authz` callout's `metadata_tls` (`include_tls`) — subject/issuer DN, `serial_number`, `fingerprint_sha256`, and the subject alternative names (`dns_names`, `uris`, `email_addresses`, `ip_addresses`) — for client-facing mTLS authorization decisions ([#873](https://github.com/coupergateway/couper/issues/873))
 
 ---
 

--- a/accesscontrol/authz/external.go
+++ b/accesscontrol/authz/external.go
@@ -2,7 +2,9 @@ package authz
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"mime"
@@ -45,11 +47,20 @@ type metadataTLS struct {
 	Version           string             `json:"version"`
 }
 
+// clientCertificate carries the fields an authorization service keys on for a client-facing
+// mTLS decision: the subject/issuer DN, the serial and SHA-256 fingerprint for allow lists or
+// pinning, validity, and the subject alternative names that often hold the real identity.
 type clientCertificate struct {
-	Issuer    string    `json:"issuer"`
-	NotAfter  time.Time `json:"not_after"`
-	NotBefore time.Time `json:"not_before"`
-	Subject   string    `json:"subject"`
+	DNSNames          []string  `json:"dns_names,omitempty"`
+	EmailAddresses    []string  `json:"email_addresses,omitempty"`
+	FingerprintSHA256 string    `json:"fingerprint_sha256,omitempty"`
+	IPAddresses       []string  `json:"ip_addresses,omitempty"`
+	Issuer            string    `json:"issuer"`
+	NotAfter          time.Time `json:"not_after"`
+	NotBefore         time.Time `json:"not_before"`
+	SerialNumber      string    `json:"serial_number,omitempty"`
+	Subject           string    `json:"subject"`
+	URIs              []string  `json:"uris,omitempty"`
 }
 
 // context sent to external authorization origin
@@ -84,12 +95,28 @@ func newMetadataTLS(state *tls.ConnectionState) *metadataTLS {
 
 	if len(state.PeerCertificates) > 0 {
 		cert := state.PeerCertificates[0]
-		meta.ClientCertificate = &clientCertificate{
-			Issuer:    cert.Issuer.String(),
-			NotAfter:  cert.NotAfter,
-			NotBefore: cert.NotBefore,
-			Subject:   cert.Subject.String(),
+		clientCert := &clientCertificate{
+			DNSNames:       cert.DNSNames,
+			EmailAddresses: cert.EmailAddresses,
+			Issuer:         cert.Issuer.String(),
+			NotAfter:       cert.NotAfter,
+			NotBefore:      cert.NotBefore,
+			Subject:        cert.Subject.String(),
 		}
+		if cert.SerialNumber != nil {
+			clientCert.SerialNumber = cert.SerialNumber.Text(16)
+		}
+		if len(cert.Raw) > 0 {
+			sum := sha256.Sum256(cert.Raw)
+			clientCert.FingerprintSHA256 = hex.EncodeToString(sum[:])
+		}
+		for _, uri := range cert.URIs {
+			clientCert.URIs = append(clientCert.URIs, uri.String())
+		}
+		for _, ip := range cert.IPAddresses {
+			clientCert.IPAddresses = append(clientCert.IPAddresses, ip.String())
+		}
+		meta.ClientCertificate = clientCert
 	}
 
 	return meta

--- a/accesscontrol/authz/external_test.go
+++ b/accesscontrol/authz/external_test.go
@@ -2,13 +2,21 @@ package authz_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/json"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -331,6 +339,20 @@ func TestExternal_Validate_PermissionsProperty(t *testing.T) {
 	})
 }
 
+func assertJSONStrings(t *testing.T, obj map[string]interface{}, key string, want []string) {
+	t.Helper()
+	values, ok := obj[key].([]interface{})
+	if !ok || len(values) != len(want) {
+		t.Errorf("%s: expected %v, got: %v", key, want, obj[key])
+		return
+	}
+	for i, w := range want {
+		if values[i] != w {
+			t.Errorf("%s[%d]: expected %q, got: %v", key, i, w, values[i])
+		}
+	}
+}
+
 func TestExternal_Validate_IncludeTLS(t *testing.T) {
 	newTLSRequest := func() *http.Request {
 		req := httptest.NewRequest(http.MethodGet, "https://client.request/protected", nil)
@@ -391,6 +413,70 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 		if cert["issuer"] != "CN=my-ca" {
 			t.Errorf("unexpected certificate issuer: %v", cert["issuer"])
 		}
+	})
+
+	t.Run("client certificate identity fields", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		spiffe, _ := url.Parse("spiffe://example.org/mcp-client")
+		template := &x509.Certificate{
+			SerialNumber:   big.NewInt(4711),
+			Subject:        pkix.Name{CommonName: "mcp-client"},
+			NotBefore:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			NotAfter:       time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+			DNSNames:       []string{"client.example"},
+			EmailAddresses: []string{"mcp@example.org"},
+			IPAddresses:    []net.IP{net.ParseIP("10.0.0.7")},
+			URIs:           []*url.URL{spiffe},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "https://client.request/protected", nil)
+		req.TLS = &tls.ConnectionState{
+			Version:          tls.VersionTLS13,
+			CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+			PeerCertificates: []*x509.Certificate{cert},
+		}
+
+		var calloutBody []byte
+		external := authz.NewExternal("test_ac", "http://authz.service/check", true, "", captureBody(&calloutBody))
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		var sent map[string]interface{}
+		if err := json.Unmarshal(calloutBody, &sent); err != nil {
+			t.Fatalf("callout body is no valid json: %v", err)
+		}
+		metaTLS, _ := sent["metadata_tls"].(map[string]interface{})
+		clientCert, _ := metaTLS["client_certificate"].(map[string]interface{})
+		if clientCert == nil {
+			t.Fatal("missing client_certificate object")
+		}
+
+		if clientCert["subject"] != "CN=mcp-client" {
+			t.Errorf("unexpected subject: %v", clientCert["subject"])
+		}
+		if clientCert["serial_number"] != "1267" { // 4711 in hex
+			t.Errorf("unexpected serial_number: %v", clientCert["serial_number"])
+		}
+		sum := sha256.Sum256(der)
+		if clientCert["fingerprint_sha256"] != hex.EncodeToString(sum[:]) {
+			t.Errorf("unexpected fingerprint_sha256: %v", clientCert["fingerprint_sha256"])
+		}
+		assertJSONStrings(t, clientCert, "dns_names", []string{"client.example"})
+		assertJSONStrings(t, clientCert, "email_addresses", []string{"mcp@example.org"})
+		assertJSONStrings(t, clientCert, "ip_addresses", []string{"10.0.0.7"})
+		assertJSONStrings(t, clientCert, "uris", []string{"spiffe://example.org/mcp-client"})
 	})
 
 	t.Run("enabled without tls connection", func(t *testing.T) {

--- a/docs/website/content/configuration/block/beta_external_authz.md
+++ b/docs/website/content/configuration/block/beta_external_authz.md
@@ -31,7 +31,9 @@ client request to the configured authorization service:
 }
 ```
 
-With `include_tls = true` the TLS connection information of the client request is added:
+With `include_tls = true` the TLS connection information of the client request is added. In a
+client-facing mTLS setup the `client_certificate` carries the fields an authorization service
+keys on — this is the full payload such a service can expect:
 
 ```json
 {
@@ -41,14 +43,25 @@ With `include_tls = true` the TLS connection information of the client request i
     "cipher_suite": "TLS_AES_128_GCM_SHA256",
     "server_name": "couper.example.com",
     "client_certificate": {
-      "subject": "CN=my-client",
+      "subject": "CN=my-client,O=Example",
       "issuer": "CN=my-ca",
+      "serial_number": "1267",
+      "fingerprint_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       "not_before": "2026-01-01T00:00:00Z",
-      "not_after": "2027-01-01T00:00:00Z"
+      "not_after": "2027-01-01T00:00:00Z",
+      "dns_names": ["client.example"],
+      "uris": ["spiffe://example.org/mcp-client"],
+      "email_addresses": ["mcp@example.org"],
+      "ip_addresses": ["10.0.0.7"]
     }
   }
 }
 ```
+
+`serial_number` is hex-encoded and `fingerprint_sha256` is the hex SHA-256 of the DER
+certificate — use either for allow lists or pinning. The subject alternative names
+(`dns_names`, `uris`, `email_addresses`, `ip_addresses`) appear only when the certificate
+carries them and often hold the identity to authorize on, e.g. a SPIFFE ID in `uris`.
 
 Couper calls the authorization service on the hot path of every protected request, so the
 connection to it should be persistent. This is the recommended setup: a (typically local)

--- a/server/http_external_authz_test.go
+++ b/server/http_external_authz_test.go
@@ -1,7 +1,10 @@
 package server_test
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -196,6 +199,85 @@ func TestExternalAuthz_HTTP2Callout(t *testing.T) {
 	}
 	if calloutConns[0] != calloutConns[1] {
 		t.Errorf("expected callouts to reuse one connection, got: %v", calloutConns)
+	}
+}
+
+func TestExternalAuthz_MTLSClientCertificate(t *testing.T) {
+	helper := test.New(t)
+
+	selfSigned, err := server.NewCertificate(time.Minute, nil, nil)
+	helper.Must(err)
+
+	var mu sync.Mutex
+	var calloutBody []byte
+	authzService := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		mu.Lock()
+		calloutBody = body
+		mu.Unlock()
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer authzService.Close()
+
+	shutdown, _, err := newCouperWithTemplate("testdata/external_authz/09_couper.hcl", helper, map[string]interface{}{
+		"origin":     authzService.URL,
+		"publicKey":  string(selfSigned.ServerCertificate.Certificate), // PEM
+		"privateKey": string(selfSigned.ServerCertificate.PrivateKey),  // PEM
+		"clientCA":   string(selfSigned.CACertificate.Certificate),     // PEM
+	})
+	helper.Must(err)
+	defer shutdown()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(selfSigned.CA.Leaf)
+	client := test.NewHTTPSClient(&tls.Config{
+		RootCAs:      pool,
+		Certificates: []tls.Certificate{*selfSigned.Client},
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://localhost:4443/protected", nil)
+	helper.Must(err)
+
+	res, err := client.Do(req)
+	helper.Must(err)
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status %d, got: %d", http.StatusNoContent, res.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var sent struct {
+		MetadataTLS *struct {
+			ClientCertificate *struct {
+				FingerprintSHA256 string `json:"fingerprint_sha256"`
+				SerialNumber      string `json:"serial_number"`
+				Subject           string `json:"subject"`
+			} `json:"client_certificate"`
+		} `json:"metadata_tls"`
+	}
+	helper.Must(json.Unmarshal(calloutBody, &sent))
+
+	if sent.MetadataTLS == nil || sent.MetadataTLS.ClientCertificate == nil {
+		t.Fatalf("expected client_certificate in callout metadata_tls, got: %s", calloutBody)
+	}
+
+	// The authorization service must see the exact client certificate Couper terminated,
+	// keyed on the fields an mTLS decision relies on.
+	leaf := selfSigned.Client.Leaf
+	cert := sent.MetadataTLS.ClientCertificate
+	if cert.SerialNumber != leaf.SerialNumber.Text(16) {
+		t.Errorf("expected serial_number %q, got: %q", leaf.SerialNumber.Text(16), cert.SerialNumber)
+	}
+	sum := sha256.Sum256(leaf.Raw)
+	if cert.FingerprintSHA256 != hex.EncodeToString(sum[:]) {
+		t.Errorf("expected fingerprint_sha256 %q, got: %q", hex.EncodeToString(sum[:]), cert.FingerprintSHA256)
+	}
+	if cert.Subject != leaf.Subject.String() {
+		t.Errorf("expected subject %q, got: %q", leaf.Subject.String(), cert.Subject)
 	}
 }
 

--- a/server/http_external_authz_test.go
+++ b/server/http_external_authz_test.go
@@ -221,9 +221,9 @@ func TestExternalAuthz_MTLSClientCertificate(t *testing.T) {
 
 	shutdown, _, err := newCouperWithTemplate("testdata/external_authz/09_couper.hcl", helper, map[string]interface{}{
 		"origin":     authzService.URL,
-		"publicKey":  string(selfSigned.ServerCertificate.Certificate), // PEM
-		"privateKey": string(selfSigned.ServerCertificate.PrivateKey),  // PEM
-		"clientCA":   string(selfSigned.CACertificate.Certificate),     // PEM
+		"publicKey":  string(selfSigned.ServerCertificate.Certificate),             // PEM
+		"privateKey": string(selfSigned.ServerCertificate.PrivateKey),              // PEM
+		"clientCA":   string(selfSigned.ClientIntermediateCertificate.Certificate), // PEM (signs the client leaf)
 	})
 	helper.Must(err)
 	defer shutdown()

--- a/server/testdata/external_authz/09_couper.hcl
+++ b/server/testdata/external_authz/09_couper.hcl
@@ -1,0 +1,37 @@
+server "protected" {
+  hosts = ["*:4443"]
+
+  api {
+    endpoint "/protected" {
+      access_control = ["authz"]
+
+      response {
+        status = 204
+      }
+    }
+  }
+
+  tls {
+    server_certificate {
+      public_key = <<-EOC
+{{ .publicKey }}
+EOC
+      private_key = <<-EOC
+{{ .privateKey }}
+EOC
+    }
+
+    client_certificate {
+      ca_certificate = <<-EOC
+{{ .clientCA }}
+EOC
+    }
+  }
+}
+
+definitions {
+  beta_external_authz "authz" {
+    url         = "{{.origin}}/check"
+    include_tls = true
+  }
+}


### PR DESCRIPTION
Enriches the `beta_external_authz` `metadata_tls.client_certificate` (`include_tls`) so an authorization service can make a client-facing **mTLS** decision. Previously only the subject/issuer DN was forwarded — too thin to authorize on.

Adds the fields such a decision actually keys on:
- `serial_number` (hex) and `fingerprint_sha256` (hex SHA-256 of the DER cert) — allow lists / pinning
- subject alternative names: `dns_names`, `uris`, `email_addresses`, `ip_addresses` — often the real identity (e.g. a SPIFFE ID in `uris`)

Nil-safe: absent serial / raw / SANs are simply omitted. Covered by a unit test (crafted SAN-rich cert → full field mapping) and a server integration test (real client-facing mTLS → the callout receives the terminated client certificate). Docs show the full example callout payload.

Stacked on top of #979 (predecessor); top of the `beta_external_authz` stack.