### PR TITLE
mux: expose the matched route pattern in the request context

### DIFF
--- a/config/request/context_key.go
+++ b/config/request/context_key.go
@@ -32,6 +32,7 @@ const (
 	ResponseWriter
 	RoundTripName
 	RoundTripProxy
+	RoutePattern
 	ServerName
 	ServerTimings
 	StartTime

--- a/server/mux.go
+++ b/server/mux.go
@@ -26,8 +26,9 @@ type Mux struct {
 }
 
 const (
-	serverOptionsKey = "serverContextOptions"
-	wildcardSearch   = "/**"
+	serverOptionsKey  = "serverContextOptions"
+	wildcardRouteName = "**"
+	wildcardSearch    = "/**"
 )
 
 func isParamSegment(segment string) bool {
@@ -127,9 +128,9 @@ func (m *Mux) FindHandler(req *http.Request) http.Handler {
 			return tpl.WithError(errors.RouteNotFound.Label(api.BasePath)) // TODO: api label
 		}
 
-		fileHandler, exist := m.hasFileResponse(req)
+		fileHandler, fileMatch, exist := m.hasFileResponse(req)
 		if exist {
-			*req = *req.WithContext(ctx)
+			*req = *req.WithContext(withRoutePattern(ctx, fileMatch))
 			return fileHandler
 		}
 
@@ -160,14 +161,36 @@ func (m *Mux) FindHandler(req *http.Request) http.Handler {
 	wc := strings.TrimPrefix(req.URL.Path, p)
 	wc = strings.TrimPrefix(wc, "/")
 
-	if routeMatch.Route.GetName() == "**" {
+	if routeMatch.Route.GetName() == wildcardRouteName {
 		ctx = context.WithValue(ctx, request.Wildcard, wc)
 	}
 
 	ctx = context.WithValue(ctx, request.PathParams, pathParams)
-	*req = *req.WithContext(ctx)
+	*req = *req.WithContext(withRoutePattern(ctx, routeMatch))
 
 	return routeMatch.Handler
+}
+
+// withRoutePattern adds the route as the operator configured it. Gorilla registers a
+// wildcard route as a prefix and drops the trailing slash variant of a path, so this
+// function makes the pattern again. Policies apply to the pattern, not to the request path.
+func withRoutePattern(ctx context.Context, routeMatch *gmux.RouteMatch) context.Context {
+	if routeMatch == nil || routeMatch.Route == nil {
+		return ctx
+	}
+
+	pattern, err := routeMatch.Route.GetPathTemplate()
+	if err != nil {
+		return ctx
+	}
+
+	if routeMatch.Route.GetName() == wildcardRouteName {
+		pattern = strings.TrimSuffix(pattern, "/") + wildcardSearch
+	} else if pattern != "/" {
+		pattern = strings.TrimSuffix(pattern, "/")
+	}
+
+	return context.WithValue(ctx, request.RoutePattern, pattern)
 }
 
 func (m *Mux) match(root *gmux.Router, req *http.Request) (*gmux.RouteMatch, bool) {
@@ -179,23 +202,23 @@ func (m *Mux) match(root *gmux.Router, req *http.Request) (*gmux.RouteMatch, boo
 	return nil, false
 }
 
-func (m *Mux) hasFileResponse(req *http.Request) (http.Handler, bool) {
+func (m *Mux) hasFileResponse(req *http.Request) (http.Handler, *gmux.RouteMatch, bool) {
 	routeMatch, matches := m.match(m.fileRoot, req)
 	if !matches {
-		return nil, false
+		return nil, nil, false
 	}
 
 	fileHandler := routeMatch.Handler
 	unprotectedHandler := getChildHandler(fileHandler)
 	if fh, ok := unprotectedHandler.(*handler.File); ok {
-		return fileHandler, fh.HasResponse(req)
+		return fileHandler, routeMatch, fh.HasResponse(req)
 	}
 
 	if fh, ok := fileHandler.(*handler.File); ok {
-		return fileHandler, fh.HasResponse(req)
+		return fileHandler, routeMatch, fh.HasResponse(req)
 	}
 
-	return fileHandler, false
+	return fileHandler, routeMatch, false
 }
 
 func (m *Mux) getAPIErrorTemplate(reqPath string) (*errors.Template, *config.API) {

--- a/server/mux.go
+++ b/server/mux.go
@@ -138,6 +138,7 @@ func (m *Mux) FindHandler(req *http.Request) http.Handler {
 
 		if !matches {
 			if fileHandler != nil {
+				*req = *req.WithContext(withRoutePattern(ctx, fileMatch))
 				return fileHandler
 			}
 
@@ -171,9 +172,10 @@ func (m *Mux) FindHandler(req *http.Request) http.Handler {
 	return routeMatch.Handler
 }
 
-// withRoutePattern adds the route as the operator configured it. Gorilla registers a
-// wildcard route as a prefix and drops the trailing slash variant of a path, so this
-// function makes the pattern again. Policies apply to the pattern, not to the request path.
+// withRoutePattern adds the registered route pattern, base path included. Couper registers
+// a wildcard route without its "/**" suffix and adds a trailing slash variant of each path,
+// so this function restores the configured pattern. Policies apply to the pattern, not to
+// the request path.
 func withRoutePattern(ctx context.Context, routeMatch *gmux.RouteMatch) context.Context {
 	if routeMatch == nil || routeMatch.Route == nil {
 		return ctx
@@ -254,14 +256,14 @@ func mustAddRoute(root *gmux.Router, path string, handler http.Handler, trailing
 	if strings.HasSuffix(path, wildcardSearch) {
 		path = path[:len(path)-len(wildcardSearch)]
 		if len(path) == 0 {
-			root.PathPrefix("/").Name("**").Handler(handler)
+			root.PathPrefix("/").Name(wildcardRouteName).Handler(handler)
 			return
 		}
-		root.Path(path).Name("**").Handler(handler) // register /path ...
+		root.Path(path).Name(wildcardRouteName).Handler(handler) // register /path ...
 		if !strings.HasSuffix(path, "/") {
 			path = path + "/" // ... and /path/**
 		}
-		root.PathPrefix(path).Name("**").Handler(handler)
+		root.PathPrefix(path).Name(wildcardRouteName).Handler(handler)
 		return
 	}
 

--- a/server/mux_test.go
+++ b/server/mux_test.go
@@ -210,6 +210,7 @@ func TestMux_FindHandler_RoutePatternContext(t *testing.T) {
 
 	testOptions := &runtime.MuxOptions{
 		EndpointRoutes: map[string]http.Handler{
+			"/":                    noContent,
 			"/without":             noContent,
 			"/with/{my}/parameter": noContent,
 			"/prefix/**":           noContent,
@@ -228,6 +229,7 @@ func TestMux_FindHandler_RoutePatternContext(t *testing.T) {
 		path    string
 		expPath string
 	}{
+		{"endpoint root", "/", "/"},
 		{"endpoint", "/without", "/without"},
 		{"endpoint, trailing slash", "/without/", "/without"},
 		{"endpoint /w path param", "/with/my123/parameter", "/with/{my}/parameter"},
@@ -235,6 +237,7 @@ func TestMux_FindHandler_RoutePatternContext(t *testing.T) {
 		{"endpoint wildcard, deep", "/prefix/deep/path", "/prefix/**"},
 		{"spa wildcard", "/app/some/route", "/app/**"},
 		{"files wildcard", "/public/robots.txt", "/public/**"},
+		{"files wildcard, missing file", "/public/missing.txt", "/public/**"},
 		{"no route", "/nothing/here", ""},
 	}
 

--- a/server/mux_test.go
+++ b/server/mux_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coupergateway/couper/config/runtime"
 	rs "github.com/coupergateway/couper/config/runtime/server"
 	"github.com/coupergateway/couper/errors"
+	"github.com/coupergateway/couper/handler"
 	"github.com/coupergateway/couper/server"
 )
 
@@ -189,5 +190,90 @@ func TestMux_FindHandler_PathParamContext(t *testing.T) {
 				subT.Errorf("Wildcard context: %q, want: %q", wildcardCtx, tt.expWildcard)
 			}
 		})
+	}
+}
+
+func TestMux_FindHandler_RoutePatternContext(t *testing.T) {
+	noContent := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusNoContent)
+	})
+
+	serverOptions, _ := rs.NewServerOptions(nil, nil)
+	serverOptions.FilesBasePaths = []string{"/public"}
+	serverOptions.SPABasePaths = []string{"/app"}
+
+	fileHandler, err := handler.NewFile("testdata/file_serving/htdocs", "/public/",
+		func(string) bool { return false }, errors.DefaultHTML, serverOptions, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testOptions := &runtime.MuxOptions{
+		EndpointRoutes: map[string]http.Handler{
+			"/without":             noContent,
+			"/with/{my}/parameter": noContent,
+			"/prefix/**":           noContent,
+		},
+		FileRoutes: map[string]http.Handler{
+			"/public/**": fileHandler,
+		},
+		SPARoutes: map[string]http.Handler{
+			"/app/**": noContent,
+		},
+		ServerOptions: serverOptions,
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		expPath string
+	}{
+		{"endpoint", "/without", "/without"},
+		{"endpoint, trailing slash", "/without/", "/without"},
+		{"endpoint /w path param", "/with/my123/parameter", "/with/{my}/parameter"},
+		{"endpoint wildcard, exact", "/prefix", "/prefix/**"},
+		{"endpoint wildcard, deep", "/prefix/deep/path", "/prefix/**"},
+		{"spa wildcard", "/app/some/route", "/app/**"},
+		{"files wildcard", "/public/robots.txt", "/public/**"},
+		{"no route", "/nothing/here", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(subT *testing.T) {
+			mux := server.NewMux(testOptions)
+			mux.RegisterConfigured()
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			mux.FindHandler(req)
+
+			pattern, _ := req.Context().Value(request.RoutePattern).(string)
+			if pattern != tt.expPath {
+				subT.Errorf("Route pattern context: %q, want: %q", pattern, tt.expPath)
+			}
+		})
+	}
+}
+
+func TestMux_FindHandler_RoutePatternContext_RootWildcard(t *testing.T) {
+	serverOptions, _ := rs.NewServerOptions(nil, nil)
+
+	testOptions := &runtime.MuxOptions{
+		EndpointRoutes: map[string]http.Handler{
+			"/**": http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+				rw.WriteHeader(http.StatusNoContent)
+			}),
+		},
+		ServerOptions: serverOptions,
+	}
+
+	mux := server.NewMux(testOptions)
+	mux.RegisterConfigured()
+
+	req := httptest.NewRequest(http.MethodGet, "/any/path", nil)
+	mux.FindHandler(req)
+
+	pattern, _ := req.Context().Value(request.RoutePattern).(string)
+	if pattern != "/**" {
+		t.Errorf("Route pattern context: %q, want: %q", pattern, "/**")
 	}
 }


### PR DESCRIPTION
First PR of the AuthZEN stack. Successor: `feat/authzen-request` (#988).

## Context

`beta_external_authz` will name the matched route as the AuthZEN resource, because a policy
applies to a route and not to a single request path. The pattern is already at hand:
`Mux.FindHandler` computes `routeMatch.Route.GetPathTemplate()` and uses it only to derive the
wildcard remainder, then throws it away.

## Change

Store the pattern under a new `request.RoutePattern` context key, next to `request.PathParams`,
for endpoint, SPA and files matches. Two normalizations make the value the pattern the operator
wrote rather than the one gorilla registered:

- a wildcard route gets its `/**` suffix back (gorilla registers it as a prefix)
- a trailing slash is trimmed, because `endpoint "/foo"` registers both `/foo` and `/foo/`

No behaviour change on its own; nothing reads the key yet.

## Verification

`TestMux_FindHandler_RoutePatternContext` covers endpoint, path parameter, wildcard (exact and
deep), SPA, files and no-match; `..._RootWildcard` covers `/**`.

## Stack

1. #987 — matched route pattern in the request context **← this PR**
2. #988 — AuthZEN 1.0 evaluation request
3. #989 — in-band decision and PEP/PDP errors
4. #990 — configurable subject, action, resource and context
5. #991 — default endpoint, X-Request-ID and design notes
6. #992 — batch permission evaluation
7. #993 — configuration discovery

Predecessor: `main`
Successor: #988

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>

