### PR TITLE
beta_external_authz: send an AuthZEN 1.0 access evaluation request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Added**
-  * `beta_external_authz` access control: delegate the authorization decision to an external service via an HTTP callout, with distinct `external_authz_invalid_credentials` (401) and `external_authz_insufficient_permissions` (403) error types and opt-in TLS connection metadata (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
+  * `beta_external_authz` access control: delegate the authorization decision to a policy decision point via an [OpenID AuthZEN Authorization API 1.0](https://openid.net/specs/authorization-api-1_0.html) access evaluation callout, with distinct `external_authz_invalid_credentials` (401) and `external_authz_insufficient_permissions` (403) error types and opt-in TLS connection state (`include_tls`) ([#873](https://github.com/coupergateway/couper/issues/873))
   * log the negotiated HTTP protocol version of backend responses (`response.proto` in `couper_backend` logs) ([#873](https://github.com/coupergateway/couper/issues/873))
   * `http2_prior_knowledge` backend attribute: cleartext HTTP/2 (h2c) for trusted `http` origins, e.g. multiplexed `beta_external_authz` callouts without TLS ([#873](https://github.com/coupergateway/couper/issues/873))
   * forward the authorization service's `WWW-Authenticate` challenge on `beta_external_authz` denials via a default `error_handler`; the value is available as `request.context.<label>.www_authenticate` ([#873](https://github.com/coupergateway/couper/issues/873))
   * expose a `beta_external_authz` callout's JSON object response body and its response headers (`request.context.<label>` / `request.context.<label>.headers`); inject a resolved identity upstream with `set_request_headers` ([#873](https://github.com/coupergateway/couper/issues/873))
   * `permissions_property` attribute for `beta_external_authz`: grant permissions for `required_permission` checks from a named response body property of the authorization service; a configured property missing from a `200` response denies the request ([#873](https://github.com/coupergateway/couper/issues/873))
-  * forward the client certificate identity in a `beta_external_authz` callout's `metadata_tls` (`include_tls`) — subject/issuer DN, `serial_number`, `fingerprint_sha256`, and the subject alternative names (`dns_names`, `uris`, `email_addresses`, `ip_addresses`) — for client-facing mTLS authorization decisions ([#873](https://github.com/coupergateway/couper/issues/873))
+  * forward the client certificate identity in a `beta_external_authz` callout's `context.tls` (`include_tls`) — subject/issuer DN, `serial_number`, `fingerprint_sha256`, and the subject alternative names (`dns_names`, `uris`, `email_addresses`, `ip_addresses`) — for client-facing mTLS authorization decisions ([#873](https://github.com/coupergateway/couper/issues/873))
 
 ---
 

--- a/accesscontrol/authz/authzen.go
+++ b/accesscontrol/authz/authzen.go
@@ -1,0 +1,121 @@
+package authz
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/coupergateway/couper/config/request"
+	"github.com/coupergateway/couper/internal/seetie"
+)
+
+// Entity types of the AuthZEN API gateway mapping.
+const (
+	subjectTypeAnonymous = "anonymous"
+	subjectTypeJWT       = "JWT"
+	resourceTypeRoute    = "route"
+	resourceTypeURI      = "uri"
+)
+
+// evaluationRequest is an AuthZEN Authorization API 1.0 access evaluation request.
+// The subject, the action and the resource are mandatory.
+type evaluationRequest struct {
+	Subject  entity                 `json:"subject"`
+	Action   action                 `json:"action"`
+	Resource entity                 `json:"resource"`
+	Context  map[string]interface{} `json:"context,omitempty"`
+}
+
+type entity struct {
+	Type       string                 `json:"type"`
+	ID         string                 `json:"id"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+type action struct {
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+func newEvaluationRequest(req *http.Request, includeTLS bool) evaluationRequest {
+	evalReq := evaluationRequest{
+		Subject:  newSubject(req.Header),
+		Action:   action{Name: req.Method},
+		Resource: newResource(req),
+		Context: map[string]interface{}{
+			"headers": seetie.HeaderToMap(req.Header),
+		},
+	}
+
+	if includeTLS {
+		if meta := newMetadataTLS(req.TLS); meta != nil {
+			evalReq.Context["tls"] = meta
+		}
+	}
+
+	return evalReq
+}
+
+// newSubject names the raw bearer token as the subject. Couper does not validate the
+// credential, the decision point does. A request without a bearer token stays anonymous,
+// because the subject type and the subject id are mandatory; its credential is still in
+// the headers, where the decision point reads it.
+func newSubject(header http.Header) entity {
+	if token := bearerToken(header); token != "" {
+		return entity{Type: subjectTypeJWT, ID: token}
+	}
+
+	return entity{Type: subjectTypeAnonymous, ID: subjectTypeAnonymous}
+}
+
+// newResource names the matched route, because a policy applies to the route and not to a
+// single request path. Without a route, for example in front of a file server, the request
+// path is the best identifier that Couper has.
+func newResource(req *http.Request) entity {
+	properties := map[string]interface{}{
+		"hostname": req.URL.Hostname(),
+		"ip":       clientIP(req.RemoteAddr),
+		"path":     req.URL.Path,
+		"scheme":   req.URL.Scheme,
+		"uri":      req.URL.String(),
+	}
+
+	if query := req.URL.Query(); len(query) > 0 {
+		properties["query"] = map[string][]string(query)
+	}
+
+	if params, ok := req.Context().Value(request.PathParams).(request.PathParameter); ok && len(params) > 0 {
+		properties["params"] = map[string]interface{}(params)
+	}
+
+	pattern, _ := req.Context().Value(request.RoutePattern).(string)
+	if pattern == "" {
+		return entity{Type: resourceTypeURI, ID: req.URL.Path, Properties: properties}
+	}
+
+	properties["route"] = pattern
+
+	return entity{Type: resourceTypeRoute, ID: pattern, Properties: properties}
+}
+
+// bearerToken is a local copy of the unexported token lookup in the accesscontrol package.
+// An import of that package would pull oauth2, oidc, backend and logging into this leaf.
+func bearerToken(header http.Header) string {
+	const prefix = "bearer "
+
+	authorization := header.Get("Authorization")
+	if len(authorization) <= len(prefix) || !strings.EqualFold(authorization[:len(prefix)], prefix) {
+		return ""
+	}
+
+	return strings.TrimSpace(authorization[len(prefix):])
+}
+
+func clientIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+
+	return host
+}

--- a/accesscontrol/authz/external.go
+++ b/accesscontrol/authz/external.go
@@ -2,16 +2,12 @@ package authz
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"io"
 	"mime"
 	"net/http"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/coupergateway/couper/config/request"
 	"github.com/coupergateway/couper/errors"
@@ -22,7 +18,7 @@ import (
 
 const roundTripName = "external_authz"
 
-// External authorization calls out to a service which decides whether the
+// External authorization calls out to a policy decision point which decides whether the
 // client request is allowed: 200 allows, 401 and 403 map to distinct error types.
 type External struct {
 	includeTLS          bool
@@ -30,43 +26,6 @@ type External struct {
 	permissionsProperty string
 	transport           http.RoundTripper
 	url                 string
-}
-
-// simplified form of http.Request for serialization
-type clientRequest struct {
-	Method  string      `json:"method"`
-	URL     string      `json:"url"`
-	Headers http.Header `json:"headers"`
-}
-
-// TLS connection information of the client request, forwarded opt-in
-type metadataTLS struct {
-	CipherSuite       string             `json:"cipher_suite"`
-	ClientCertificate *clientCertificate `json:"client_certificate,omitempty"`
-	ServerName        string             `json:"server_name,omitempty"`
-	Version           string             `json:"version"`
-}
-
-// clientCertificate carries the fields an authorization service keys on for a client-facing
-// mTLS decision: the subject/issuer DN, the serial and SHA-256 fingerprint for allow lists or
-// pinning, validity, and the subject alternative names that often hold the real identity.
-type clientCertificate struct {
-	DNSNames          []string  `json:"dns_names,omitempty"`
-	EmailAddresses    []string  `json:"email_addresses,omitempty"`
-	FingerprintSHA256 string    `json:"fingerprint_sha256,omitempty"`
-	IPAddresses       []string  `json:"ip_addresses,omitempty"`
-	Issuer            string    `json:"issuer"`
-	NotAfter          time.Time `json:"not_after"`
-	NotBefore         time.Time `json:"not_before"`
-	SerialNumber      string    `json:"serial_number,omitempty"`
-	Subject           string    `json:"subject"`
-	URIs              []string  `json:"uris,omitempty"`
-}
-
-// context sent to external authorization origin
-type authContext struct {
-	ClientRequest clientRequest `json:"client_request"`
-	MetadataTLS   *metadataTLS  `json:"metadata_tls,omitempty"`
 }
 
 func NewExternal(name, calloutURL string, includeTLS bool, permissionsProperty string, transport http.RoundTripper) *External {
@@ -82,59 +41,8 @@ func NewExternal(name, calloutURL string, includeTLS bool, permissionsProperty s
 	}
 }
 
-func newMetadataTLS(state *tls.ConnectionState) *metadataTLS {
-	if state == nil {
-		return nil
-	}
-
-	meta := &metadataTLS{
-		CipherSuite: tls.CipherSuiteName(state.CipherSuite),
-		ServerName:  state.ServerName,
-		Version:     tls.VersionName(state.Version),
-	}
-
-	if len(state.PeerCertificates) > 0 {
-		cert := state.PeerCertificates[0]
-		clientCert := &clientCertificate{
-			DNSNames:       cert.DNSNames,
-			EmailAddresses: cert.EmailAddresses,
-			Issuer:         cert.Issuer.String(),
-			NotAfter:       cert.NotAfter,
-			NotBefore:      cert.NotBefore,
-			Subject:        cert.Subject.String(),
-		}
-		if cert.SerialNumber != nil {
-			clientCert.SerialNumber = cert.SerialNumber.Text(16)
-		}
-		if len(cert.Raw) > 0 {
-			sum := sha256.Sum256(cert.Raw)
-			clientCert.FingerprintSHA256 = hex.EncodeToString(sum[:])
-		}
-		for _, uri := range cert.URIs {
-			clientCert.URIs = append(clientCert.URIs, uri.String())
-		}
-		for _, ip := range cert.IPAddresses {
-			clientCert.IPAddresses = append(clientCert.IPAddresses, ip.String())
-		}
-		meta.ClientCertificate = clientCert
-	}
-
-	return meta
-}
-
 func (e *External) Validate(req *http.Request) error {
-	authCtx := authContext{
-		ClientRequest: clientRequest{
-			Method:  req.Method,
-			URL:     req.URL.String(),
-			Headers: req.Header,
-		},
-	}
-	if e.includeTLS {
-		authCtx.MetadataTLS = newMetadataTLS(req.TLS)
-	}
-
-	body, err := json.Marshal(authCtx)
+	body, err := json.Marshal(newEvaluationRequest(req, e.includeTLS))
 	if err != nil {
 		return errors.ExternalAuthz.Label(e.name).With(err)
 	}

--- a/accesscontrol/authz/external_test.go
+++ b/accesscontrol/authz/external_test.go
@@ -77,54 +77,161 @@ func TestExternal_Validate_Status(t *testing.T) {
 	}
 }
 
-func TestExternal_Validate_CalloutRequest(t *testing.T) {
+// captureCallout returns the transport plus pointers to the callout request and its body.
+func captureCallout(status int) (roundTripperFunc, **http.Request, *[]byte) {
 	var calloutReq *http.Request
 	var calloutBody []byte
 
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		calloutReq = req
 		calloutBody, _ = io.ReadAll(req.Body)
-		return respondStatus(http.StatusOK)(req)
+		return respondStatus(status)(req)
 	})
 
+	return transport, &calloutReq, &calloutBody
+}
+
+func decodeCallout(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+
+	var sent map[string]interface{}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("callout body is no valid json: %v", err)
+	}
+
+	return sent
+}
+
+func objectAt(t *testing.T, parent map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+
+	child, _ := parent[key].(map[string]interface{})
+	if child == nil {
+		t.Fatalf("missing %q object in %v", key, parent)
+	}
+
+	return child
+}
+
+func TestExternal_Validate_CalloutRequest(t *testing.T) {
+	transport, calloutReq, calloutBody := captureCallout(http.StatusOK)
 	external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", transport)
 
-	req := httptest.NewRequest(http.MethodDelete, "http://client.request/protected?a=b", nil)
+	req := httptest.NewRequest(http.MethodDelete, "http://client.request/todos/42?a=b", nil)
 	req.Header.Set("Authorization", "Bearer my-token")
+	req.RemoteAddr = "10.0.0.7:54321"
+	ctx := context.WithValue(req.Context(), request.RoutePattern, "/todos/{id}")
+	ctx = context.WithValue(ctx, request.PathParams, request.PathParameter{"id": "42"})
+	req = req.WithContext(ctx)
 
 	if err := external.Validate(req); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if calloutReq.Method != http.MethodPost {
-		t.Errorf("expected POST callout, got: %s", calloutReq.Method)
+	if (*calloutReq).Method != http.MethodPost {
+		t.Errorf("expected POST callout, got: %s", (*calloutReq).Method)
 	}
-	if calloutReq.URL.String() != "http://authz.service/check" {
-		t.Errorf("unexpected callout url: %s", calloutReq.URL)
+	if (*calloutReq).URL.String() != "http://authz.service/check" {
+		t.Errorf("unexpected callout url: %s", (*calloutReq).URL)
 	}
-	if ct := calloutReq.Header.Get("Content-Type"); ct != "application/json" {
+	if ct := (*calloutReq).Header.Get("Content-Type"); ct != "application/json" {
 		t.Errorf("unexpected content type: %q", ct)
 	}
 
-	var sent map[string]interface{}
-	if err := json.Unmarshal(calloutBody, &sent); err != nil {
-		t.Fatalf("callout body is no valid json: %v", err)
+	sent := decodeCallout(t, *calloutBody)
+
+	subject := objectAt(t, sent, "subject")
+	if subject["type"] != "JWT" {
+		t.Errorf("unexpected subject type: %v", subject["type"])
+	}
+	if subject["id"] != "my-token" {
+		t.Errorf("unexpected subject id: %v", subject["id"])
 	}
 
-	clientRequest, _ := sent["client_request"].(map[string]interface{})
-	if clientRequest == nil {
-		t.Fatal("missing client_request object")
+	action := objectAt(t, sent, "action")
+	if action["name"] != http.MethodDelete {
+		t.Errorf("unexpected action name: %v", action["name"])
 	}
-	if clientRequest["method"] != http.MethodDelete {
-		t.Errorf("expected serialized method DELETE, got: %v", clientRequest["method"])
+
+	resource := objectAt(t, sent, "resource")
+	if resource["type"] != "route" {
+		t.Errorf("unexpected resource type: %v", resource["type"])
 	}
-	if url, _ := clientRequest["url"].(string); !strings.HasSuffix(url, "/protected?a=b") {
-		t.Errorf("unexpected serialized url: %v", clientRequest["url"])
+	if resource["id"] != "/todos/{id}" {
+		t.Errorf("unexpected resource id: %v", resource["id"])
 	}
-	headers, _ := clientRequest["headers"].(map[string]interface{})
-	if headers == nil || headers["Authorization"] == nil {
-		t.Errorf("expected serialized authorization header, got: %v", clientRequest["headers"])
+
+	properties := objectAt(t, resource, "properties")
+	for key, want := range map[string]string{
+		"hostname": "client.request",
+		"ip":       "10.0.0.7",
+		"path":     "/todos/42",
+		"route":    "/todos/{id}",
+		"scheme":   "http",
+		"uri":      "http://client.request/todos/42?a=b",
+	} {
+		if properties[key] != want {
+			t.Errorf("resource property %q: expected %q, got: %v", key, want, properties[key])
+		}
 	}
+	assertJSONStrings(t, objectAt(t, properties, "query"), "a", []string{"b"})
+	if params := objectAt(t, properties, "params"); params["id"] != "42" {
+		t.Errorf("unexpected path parameters: %v", params)
+	}
+
+	headers := objectAt(t, objectAt(t, sent, "context"), "headers")
+	if headers["authorization"] != "Bearer my-token" {
+		t.Errorf("unexpected authorization header: %v", headers["authorization"])
+	}
+}
+
+func TestExternal_Validate_CalloutRequest_Fallbacks(t *testing.T) {
+	t.Run("anonymous subject without bearer token", func(t *testing.T) {
+		transport, _, calloutBody := captureCallout(http.StatusOK)
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", transport)
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/protected", nil)
+		req.Header.Set("X-Api-Key", "opaque-key")
+
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		sent := decodeCallout(t, *calloutBody)
+		subject := objectAt(t, sent, "subject")
+		if subject["type"] != "anonymous" || subject["id"] != "anonymous" {
+			t.Errorf("expected anonymous subject, got: %v", subject)
+		}
+
+		// the opaque credential must stay reachable for the decision point
+		headers := objectAt(t, objectAt(t, sent, "context"), "headers")
+		if headers["x-api-key"] != "opaque-key" {
+			t.Errorf("unexpected api key header: %v", headers["x-api-key"])
+		}
+	})
+
+	t.Run("uri resource without route pattern", func(t *testing.T) {
+		transport, _, calloutBody := captureCallout(http.StatusOK)
+		external := authz.NewExternal("test_ac", "http://authz.service/check", false, "", transport)
+
+		req := httptest.NewRequest(http.MethodGet, "http://client.request/static/logo.svg", nil)
+
+		if err := external.Validate(req); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		sent := decodeCallout(t, *calloutBody)
+		resource := objectAt(t, sent, "resource")
+		if resource["type"] != "uri" {
+			t.Errorf("unexpected resource type: %v", resource["type"])
+		}
+		if resource["id"] != "/static/logo.svg" {
+			t.Errorf("unexpected resource id: %v", resource["id"])
+		}
+		if _, exist := objectAt(t, resource, "properties")["route"]; exist {
+			t.Error("expected no route property without a matched route")
+		}
+	})
 }
 
 func TestExternal_Validate_ContextPropagation(t *testing.T) {
@@ -385,15 +492,9 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 			t.Fatalf("expected no error, got: %v", err)
 		}
 
-		var sent map[string]interface{}
-		if err := json.Unmarshal(calloutBody, &sent); err != nil {
-			t.Fatalf("callout body is no valid json: %v", err)
-		}
+		sent := decodeCallout(t, calloutBody)
 
-		metaTLS, _ := sent["metadata_tls"].(map[string]interface{})
-		if metaTLS == nil {
-			t.Fatal("missing metadata_tls object")
-		}
+		metaTLS := objectAt(t, objectAt(t, sent, "context"), "tls")
 		if metaTLS["version"] != "TLS 1.3" {
 			t.Errorf("unexpected tls version: %v", metaTLS["version"])
 		}
@@ -453,15 +554,9 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 			t.Fatalf("expected no error, got: %v", err)
 		}
 
-		var sent map[string]interface{}
-		if err := json.Unmarshal(calloutBody, &sent); err != nil {
-			t.Fatalf("callout body is no valid json: %v", err)
-		}
-		metaTLS, _ := sent["metadata_tls"].(map[string]interface{})
-		clientCert, _ := metaTLS["client_certificate"].(map[string]interface{})
-		if clientCert == nil {
-			t.Fatal("missing client_certificate object")
-		}
+		sent := decodeCallout(t, calloutBody)
+		metaTLS := objectAt(t, objectAt(t, sent, "context"), "tls")
+		clientCert := objectAt(t, metaTLS, "client_certificate")
 
 		if clientCert["subject"] != "CN=mcp-client" {
 			t.Errorf("unexpected subject: %v", clientCert["subject"])
@@ -488,12 +583,9 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 			t.Fatalf("expected no error, got: %v", err)
 		}
 
-		var sent map[string]interface{}
-		if err := json.Unmarshal(calloutBody, &sent); err != nil {
-			t.Fatalf("callout body is no valid json: %v", err)
-		}
-		if _, exist := sent["metadata_tls"]; exist {
-			t.Error("expected no metadata_tls object for non-tls connection")
+		sent := decodeCallout(t, calloutBody)
+		if _, exist := objectAt(t, sent, "context")["tls"]; exist {
+			t.Error("expected no tls context for a non-tls connection")
 		}
 	})
 
@@ -505,12 +597,9 @@ func TestExternal_Validate_IncludeTLS(t *testing.T) {
 			t.Fatalf("expected no error, got: %v", err)
 		}
 
-		var sent map[string]interface{}
-		if err := json.Unmarshal(calloutBody, &sent); err != nil {
-			t.Fatalf("callout body is no valid json: %v", err)
-		}
-		if _, exist := sent["metadata_tls"]; exist {
-			t.Error("expected no metadata_tls object when include_tls is disabled")
+		sent := decodeCallout(t, calloutBody)
+		if _, exist := objectAt(t, sent, "context")["tls"]; exist {
+			t.Error("expected no tls context when include_tls is disabled")
 		}
 	})
 }

--- a/accesscontrol/authz/tls_metadata.go
+++ b/accesscontrol/authz/tls_metadata.go
@@ -1,0 +1,74 @@
+package authz
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"time"
+)
+
+// metadataTLS holds the TLS connection state of the client request. Couper sends it as a
+// fact about the request, not as a statement about the principal: the certificate can
+// belong to a mesh sidecar while a bearer token identifies the caller.
+type metadataTLS struct {
+	CipherSuite       string             `json:"cipher_suite"`
+	ClientCertificate *clientCertificate `json:"client_certificate,omitempty"`
+	ServerName        string             `json:"server_name,omitempty"`
+	Version           string             `json:"version"`
+}
+
+// clientCertificate carries the fields an authorization service keys on for a client-facing
+// mTLS decision: the subject/issuer DN, the serial and SHA-256 fingerprint for allow lists or
+// pinning, validity, and the subject alternative names that often hold the real identity.
+type clientCertificate struct {
+	DNSNames          []string  `json:"dns_names,omitempty"`
+	EmailAddresses    []string  `json:"email_addresses,omitempty"`
+	FingerprintSHA256 string    `json:"fingerprint_sha256,omitempty"`
+	IPAddresses       []string  `json:"ip_addresses,omitempty"`
+	Issuer            string    `json:"issuer"`
+	NotAfter          time.Time `json:"not_after"`
+	NotBefore         time.Time `json:"not_before"`
+	SerialNumber      string    `json:"serial_number,omitempty"`
+	Subject           string    `json:"subject"`
+	URIs              []string  `json:"uris,omitempty"`
+}
+
+func newMetadataTLS(state *tls.ConnectionState) *metadataTLS {
+	if state == nil {
+		return nil
+	}
+
+	meta := &metadataTLS{
+		CipherSuite: tls.CipherSuiteName(state.CipherSuite),
+		ServerName:  state.ServerName,
+		Version:     tls.VersionName(state.Version),
+	}
+
+	if len(state.PeerCertificates) > 0 {
+		cert := state.PeerCertificates[0]
+		clientCert := &clientCertificate{
+			DNSNames:       cert.DNSNames,
+			EmailAddresses: cert.EmailAddresses,
+			Issuer:         cert.Issuer.String(),
+			NotAfter:       cert.NotAfter,
+			NotBefore:      cert.NotBefore,
+			Subject:        cert.Subject.String(),
+		}
+		if cert.SerialNumber != nil {
+			clientCert.SerialNumber = cert.SerialNumber.Text(16)
+		}
+		if len(cert.Raw) > 0 {
+			sum := sha256.Sum256(cert.Raw)
+			clientCert.FingerprintSHA256 = hex.EncodeToString(sum[:])
+		}
+		for _, uri := range cert.URIs {
+			clientCert.URIs = append(clientCert.URIs, uri.String())
+		}
+		for _, ip := range cert.IPAddresses {
+			clientCert.IPAddresses = append(clientCert.IPAddresses, ip.String())
+		}
+		meta.ClientCertificate = clientCert
+	}
+
+	return meta
+}

--- a/docs/website/content/configuration/block/beta_external_authz.md
+++ b/docs/website/content/configuration/block/beta_external_authz.md
@@ -16,43 +16,82 @@ types, the `beta_external_authz` block is defined in the
 [`definitions` block](/configuration/block/definitions) and can be referenced in all
 configuration blocks by its required _label_.
 
-For every protected request Couper sends a `POST` request with a JSON body describing the
-client request to the configured authorization service:
+For every protected request Couper sends a `POST` request to the configured authorization
+service. The body is an access evaluation request of the
+[OpenID AuthZEN Authorization API 1.0](https://openid.net/specs/authorization-api-1_0.html).
+Couper is the policy enforcement point (PEP), the authorization service is the policy decision
+point (PDP):
 
 ```json
 {
-  "client_request": {
-    "method": "GET",
-    "url": "https://couper.example.com/protected",
+  "subject": {
+    "type": "JWT",
+    "id": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+  },
+  "action": {
+    "name": "GET"
+  },
+  "resource": {
+    "type": "route",
+    "id": "/todos/{todoId}",
+    "properties": {
+      "uri": "https://couper.example.com/todos/42?full=1",
+      "scheme": "https",
+      "hostname": "couper.example.com",
+      "path": "/todos/42",
+      "route": "/todos/{todoId}",
+      "params": { "todoId": "42" },
+      "query": { "full": ["1"] },
+      "ip": "10.0.0.7"
+    }
+  },
+  "context": {
     "headers": {
-      "Authorization": ["Bearer ..."]
+      "authorization": "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
     }
   }
 }
 ```
 
-With `include_tls = true` the TLS connection information of the client request is added. In a
+The `subject` names the credential, not a validated principal. Couper does not validate the
+credential, the authorization service does. For a request with a bearer token the type is `JWT`
+and the `id` is the raw token. For a request without a bearer token the type is `anonymous`. Its
+credential, an API key for example, is still in `context.headers`, where the authorization
+service reads it.
+
+The `resource` names the matched route, because a policy applies to the route and not to a
+single request path. The `id` keeps the placeholders of the route, for example `/todos/{todoId}`.
+If no route matched, for example in front of a [`files` block](/configuration/block/files), the
+type is `uri` and the `id` is the request path.
+
+`context.headers` holds all request headers with lower-case names and the first value of each
+header, like the [`request.headers` variable](/configuration/variables#request).
+
+With `include_tls = true` Couper adds the TLS connection state of the client request to
+`context.tls`. This state is a fact about the request, not a statement about the principal: the
+certificate can belong to a mesh sidecar while a bearer token identifies the caller. In a
 client-facing mTLS setup the `client_certificate` carries the fields an authorization service
-keys on — this is the full payload such a service can expect:
+keys on — this is the full object such a service can expect:
 
 ```json
 {
-  "client_request": { "...": "..." },
-  "metadata_tls": {
-    "version": "TLS 1.3",
-    "cipher_suite": "TLS_AES_128_GCM_SHA256",
-    "server_name": "couper.example.com",
-    "client_certificate": {
-      "subject": "CN=my-client,O=Example",
-      "issuer": "CN=my-ca",
-      "serial_number": "1267",
-      "fingerprint_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-      "not_before": "2026-01-01T00:00:00Z",
-      "not_after": "2027-01-01T00:00:00Z",
-      "dns_names": ["client.example"],
-      "uris": ["spiffe://example.org/mcp-client"],
-      "email_addresses": ["mcp@example.org"],
-      "ip_addresses": ["10.0.0.7"]
+  "context": {
+    "tls": {
+      "version": "TLS 1.3",
+      "cipher_suite": "TLS_AES_128_GCM_SHA256",
+      "server_name": "couper.example.com",
+      "client_certificate": {
+        "subject": "CN=my-client,O=Example",
+        "issuer": "CN=my-ca",
+        "serial_number": "1267",
+        "fingerprint_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "not_before": "2026-01-01T00:00:00Z",
+        "not_after": "2027-01-01T00:00:00Z",
+        "dns_names": ["client.example"],
+        "uris": ["spiffe://example.org/mcp-client"],
+        "email_addresses": ["mcp@example.org"],
+        "ip_addresses": ["10.0.0.7"]
+      }
     }
   }
 }

--- a/server/http_external_authz_test.go
+++ b/server/http_external_authz_test.go
@@ -251,24 +251,26 @@ func TestExternalAuthz_MTLSClientCertificate(t *testing.T) {
 	defer mu.Unlock()
 
 	var sent struct {
-		MetadataTLS *struct {
-			ClientCertificate *struct {
-				FingerprintSHA256 string `json:"fingerprint_sha256"`
-				SerialNumber      string `json:"serial_number"`
-				Subject           string `json:"subject"`
-			} `json:"client_certificate"`
-		} `json:"metadata_tls"`
+		Context struct {
+			TLS *struct {
+				ClientCertificate *struct {
+					FingerprintSHA256 string `json:"fingerprint_sha256"`
+					SerialNumber      string `json:"serial_number"`
+					Subject           string `json:"subject"`
+				} `json:"client_certificate"`
+			} `json:"tls"`
+		} `json:"context"`
 	}
 	helper.Must(json.Unmarshal(calloutBody, &sent))
 
-	if sent.MetadataTLS == nil || sent.MetadataTLS.ClientCertificate == nil {
-		t.Fatalf("expected client_certificate in callout metadata_tls, got: %s", calloutBody)
+	if sent.Context.TLS == nil || sent.Context.TLS.ClientCertificate == nil {
+		t.Fatalf("expected client_certificate in callout context.tls, got: %s", calloutBody)
 	}
 
 	// The authorization service must see the exact client certificate Couper terminated,
 	// keyed on the fields an mTLS decision relies on.
 	leaf := selfSigned.Client.Leaf
-	cert := sent.MetadataTLS.ClientCertificate
+	cert := sent.Context.TLS.ClientCertificate
 	if cert.SerialNumber != leaf.SerialNumber.Text(16) {
 		t.Errorf("expected serial_number %q, got: %q", leaf.SerialNumber.Text(16), cert.SerialNumber)
 	}

--- a/server/testdata/external_authz/01_couper.hcl
+++ b/server/testdata/external_authz/01_couper.hcl
@@ -18,7 +18,7 @@ server "authz-service" {
   api {
     endpoint "/check" {
       response {
-        status = lookup(request.json_body.client_request.headers, "Authorization", [""])[0] == "Bearer valid" ? 200 : (lookup(request.json_body.client_request.headers, "Authorization", [""])[0] == "" ? 401 : 403)
+        status = request.json_body.subject.id == "valid" ? 200 : (request.json_body.subject.type == "anonymous" ? 401 : 403)
       }
     }
   }

--- a/server/testdata/external_authz/06_couper.hcl
+++ b/server/testdata/external_authz/06_couper.hcl
@@ -20,7 +20,7 @@ server "authz-service" {
     endpoint "/check" {
       response {
         json_body = {
-          granted_permissions = lookup(request.json_body.client_request.headers, "Authorization", [""])[0] == "Bearer reader" ? ["can_read", "can_list"] : ["can_list"]
+          granted_permissions = request.json_body.subject.id == "reader" ? ["can_read", "can_list"] : ["can_list"]
         }
       }
     }


### PR DESCRIPTION
Stacked on #987 (`feat/authzen-route-pattern`). Successor: `feat/authzen-decision` (#989).

## Context

The callout payload was a Couper-only schema (`client_request` / `metadata_tls`), and
`accesscontrol/authz/DESIGN.md` §6 flagged exactly that as an open item: *"Consider Envoy
`ext_authz` wire compatibility … instead of introducing a Couper-only context schema."*

The OpenID **AuthZEN Authorization API 1.0** went Final on 2026-01-11. Envoy, Kong, Tyk, Zuplo
and the AWS API Gateway implement it in the interop programme, so Couper shares the wire format
with Topaz/Aserto, Axiomatics, SGNL, Cerbos and OPA. Note: the interop gateway policies key
`subject.id` on the JWT `sub` claim; matching them needs the configurable `subject` from #990.

The feature is **unreleased** — every CHANGELOG entry sits under `[Unreleased]`. The schema is
therefore replaced outright rather than kept behind a compatibility switch, which would cost two
schemas, two error mappings and two test matrices forever.

## Change

`subject` / `action` / `resource` / `context` replace `client_request` / `metadata_tls`:

| before | after |
|---|---|
| `client_request.method` | `action.name` |
| `client_request.url` | `resource.properties.{uri,scheme,hostname,path,query}` |
| `client_request.headers` | `context.headers` |
| `metadata_tls` | `context.tls` |
| — | `resource.type` / `resource.id` = matched route |

`subject` names the credential, not a validated principal: a bearer token becomes
`{"type": "JWT", "id": "<raw token>"}`. This is a deliberate Couper default — Couper does not
validate the token, so it does not assert a principal; the spec leaves entity types open. A
preceding `jwt` access control plus the `subject` attribute (#990) sets a resolved principal.
Otherwise the subject is `anonymous` and the credential stays reachable in `context.headers`.

`context.tls` and not `subject.properties`, because Couper has not claimed that the certificate
is the principal — it can be a mesh sidecar cert while a bearer token identifies the caller.

**Note for review:** `accesscontrol/authz/tls_metadata.go` is a verbatim move out of
`external.go`; the diff there is relocation only.

## Verification

`TestExternal_Validate_CalloutRequest` asserts the full envelope, `..._Fallbacks` the anonymous
subject and the `uri` resource. The integration fixtures keep modelling the decision point as a
second Couper `server` block, which now reads `request.json_body.subject.id`.

## Stack

1. #987 — matched route pattern in the request context
2. #988 — AuthZEN 1.0 evaluation request **← this PR**
3. #989 — in-band decision and PEP/PDP errors
4. #990 — configurable subject, action, resource and context
5. #991 — default endpoint, X-Request-ID and design notes
6. #992 — batch permission evaluation
7. #993 — configuration discovery

Predecessor: #987
Successor: #989

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>


