### PR TITLE
beta_authzen: warn when the chain leaves the subject anonymous

### DIFF
--- a/config/runtime/authzen_subject_test.go
+++ b/config/runtime/authzen_subject_test.go
@@ -1,0 +1,158 @@
+package runtime_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/coupergateway/couper/cache"
+	"github.com/coupergateway/couper/config/configload"
+	"github.com/coupergateway/couper/config/runtime"
+	"github.com/coupergateway/couper/internal/test"
+)
+
+func TestAuthZenAnonymousSubjectWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		hcl     string
+		warning string
+	}{
+		{
+			"basic_auth before beta_authzen without subject",
+			`server {
+			   api {
+			     access_control = ["ba", "authz"]
+			     endpoint "/" {
+			       response {}
+			     }
+			   }
+			 }`,
+			`beta_authzen "authz" runs behind basic_auth "ba" (request.context.ba.user) without a subject attribute`,
+		},
+		{
+			"chain split over server and endpoint",
+			`server {
+			   access_control = ["ba"]
+			   endpoint "/" {
+			     access_control = ["authz"]
+			     response {}
+			   }
+			 }`,
+			`beta_authzen "authz" runs behind basic_auth "ba" (request.context.ba.user) without a subject attribute`,
+		},
+		{
+			"subject attribute set",
+			`server {
+			   api {
+			     access_control = ["ba", "authz_subject"]
+			     endpoint "/" {
+			       response {}
+			     }
+			   }
+			 }`,
+			"",
+		},
+		{
+			"jwt before beta_authzen",
+			`server {
+			   api {
+			     access_control = ["token", "authz"]
+			     endpoint "/" {
+			       response {}
+			     }
+			   }
+			 }`,
+			"",
+		},
+		{
+			"beta_authzen before basic_auth",
+			`server {
+			   api {
+			     access_control = ["authz", "ba"]
+			     endpoint "/" {
+			       response {}
+			     }
+			   }
+			 }`,
+			"",
+		},
+		{
+			"basic_auth disabled at the endpoint",
+			`server {
+			   access_control = ["ba"]
+			   endpoint "/" {
+			     disable_access_control = ["ba"]
+			     access_control = ["authz"]
+			     response {}
+			   }
+			 }`,
+			"",
+		},
+	}
+
+	template := `
+		%%
+		definitions {
+		  basic_auth "ba" {
+		    password = "asdf"
+		  }
+		  jwt "token" {
+		    signature_algorithm = "HS256"
+		    key = "asdf"
+		  }
+		  beta_authzen "authz" {
+		    url = "http://localhost:8081/access/v1/evaluation"
+		  }
+		  beta_authzen "authz_subject" {
+		    url = "http://localhost:8081/access/v1/evaluation"
+		    subject = {
+		      type = "identity"
+		      id   = request.context.ba.user
+		    }
+		  }
+		}
+	`
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(subT *testing.T) {
+			conf, err := configload.LoadBytes([]byte(strings.Replace(template, "%%", tt.hcl, 1)), "couper.hcl")
+			if err != nil {
+				subT.Fatal(err)
+			}
+			log, hook := test.NewLogger()
+			logger := log.WithContext(context.TODO())
+			tmpStoreCh := make(chan struct{})
+			defer close(tmpStoreCh)
+
+			ctx, cancel := context.WithCancel(conf.Context)
+			conf.Context = ctx
+			defer cancel()
+
+			if _, err = runtime.NewServerConfiguration(conf, logger, cache.New(logger, tmpStoreCh)); err != nil {
+				subT.Fatal(err)
+			}
+
+			var warnings []string
+			for _, entry := range hook.AllEntries() {
+				if entry.Level == logrus.WarnLevel {
+					warnings = append(warnings, entry.Message)
+				}
+			}
+
+			if tt.warning == "" {
+				if len(warnings) > 0 {
+					subT.Errorf("expected no warning, got: %v", warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 {
+				subT.Fatalf("expected exactly one warning, got: %v", warnings)
+			}
+			if !strings.Contains(warnings[0], tt.warning) {
+				subT.Errorf("unexpected warning,\nwant: %s\ngot:  %s", tt.warning, warnings[0])
+			}
+		})
+	}
+}

--- a/config/runtime/authzen_subject_test.go
+++ b/config/runtime/authzen_subject_test.go
@@ -67,6 +67,30 @@ func TestAuthZenAnonymousSubjectWarning(t *testing.T) {
 			"",
 		},
 		{
+			"jwt between basic_auth and beta_authzen",
+			`server {
+			   api {
+			     access_control = ["ba", "token", "authz"]
+			     endpoint "/" {
+			       response {}
+			     }
+			   }
+			 }`,
+			"",
+		},
+		{
+			"cookie jwt between basic_auth and beta_authzen",
+			`server {
+			   api {
+			     access_control = ["ba", "cookie_token", "authz"]
+			     endpoint "/" {
+			       response {}
+			     }
+			   }
+			 }`,
+			`beta_authzen "authz" runs behind basic_auth "ba" (request.context.ba.user) without a subject attribute`,
+		},
+		{
 			"beta_authzen before basic_auth",
 			`server {
 			   api {
@@ -101,6 +125,11 @@ func TestAuthZenAnonymousSubjectWarning(t *testing.T) {
 		  jwt "token" {
 		    signature_algorithm = "HS256"
 		    key = "asdf"
+		  }
+		  jwt "cookie_token" {
+		    signature_algorithm = "HS256"
+		    key = "asdf"
+		    cookie = "tok"
 		  }
 		  beta_authzen "authz" {
 		    url = "http://localhost:8081/access/v1/evaluation"

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -569,12 +569,29 @@ func warnAnonymousAuthZenSubject(conf *config.Couper, log *logrus.Entry) {
 		return
 	}
 
+	// A jwt reading from the Authorization Bearer header proves the token the default subject
+	// carries; one reading from a cookie, another header, an expression or a DPoP header does not.
+	bearerJWT := make(map[string]bool)
+	for _, c := range conf.Definitions.JWT {
+		if c.Cookie != "" || c.Dpop || (c.Header != "" && strings.ToLower(c.Header) != "authorization") {
+			continue
+		}
+		if tv, err := c.TokenValue.Value(nil); err != nil || !tv.IsNull() {
+			continue
+		}
+		bearerJWT[c.Name] = true
+	}
+
 	warned := make(map[string]bool)
 	warnChain := func(chain []string) {
 		var preceding string
 		for _, name := range chain {
 			if described, ok := nonBearerAuthn[name]; ok {
 				preceding = described
+				continue
+			}
+			if bearerJWT[name] {
+				preceding = ""
 				continue
 			}
 			if !authZenWithoutSubject[name] || preceding == "" {

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -110,6 +110,8 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 		return nil, acErr
 	}
 
+	warnAnonymousAuthZenSubject(conf, log)
+
 	var (
 		serverConfiguration = make(ServerConfiguration)
 		defaultPort         = conf.Settings.DefaultPort
@@ -528,6 +530,83 @@ func configureOidcConfigs(conf *config.Couper, confCtx *hcl.EvalContext, log *lo
 	}
 
 	return oidcConfigs, nil
+}
+
+// warnAnonymousAuthZenSubject flags a beta_authzen without a subject attribute running behind
+// an access control that authenticates without a bearer token: the evaluation subject stays
+// "anonymous" although the chain resolved an identity into request.context.
+func warnAnonymousAuthZenSubject(conf *config.Couper, log *logrus.Entry) {
+	if conf.Definitions == nil {
+		return
+	}
+
+	authZenWithoutSubject := make(map[string]bool)
+	for _, a := range conf.Definitions.AuthZen {
+		if _, set := a.HCLBody().Attributes["subject"]; !set {
+			authZenWithoutSubject[a.Name] = true
+		}
+	}
+	if len(authZenWithoutSubject) == 0 {
+		return
+	}
+
+	// The subject accessor the preceding control resolves its identity into; beta_oauth2 has
+	// none, its token response is not required to carry an identity.
+	nonBearerAuthn := make(map[string]string)
+	for _, c := range conf.Definitions.BasicAuth {
+		nonBearerAuthn[c.Name] = fmt.Sprintf("basic_auth %q (request.context.%s.user)", c.Name, c.Name)
+	}
+	for _, c := range conf.Definitions.SAML {
+		nonBearerAuthn[c.Name] = fmt.Sprintf("saml %q (request.context.%s.sub)", c.Name, c.Name)
+	}
+	for _, c := range conf.Definitions.OIDC {
+		nonBearerAuthn[c.Name] = fmt.Sprintf("oidc %q (request.context.%s.id_token_claims.sub)", c.Name, c.Name)
+	}
+	for _, c := range conf.Definitions.OAuth2AC {
+		nonBearerAuthn[c.Name] = fmt.Sprintf("beta_oauth2 %q", c.Name)
+	}
+	if len(nonBearerAuthn) == 0 {
+		return
+	}
+
+	warned := make(map[string]bool)
+	warnChain := func(chain []string) {
+		var preceding string
+		for _, name := range chain {
+			if described, ok := nonBearerAuthn[name]; ok {
+				preceding = described
+				continue
+			}
+			if !authZenWithoutSubject[name] || preceding == "" {
+				continue
+			}
+			key := name + "|" + preceding
+			if warned[key] {
+				continue
+			}
+			warned[key] = true
+			log.Warnf("beta_authzen %q runs behind %s without a subject attribute: the evaluation subject stays anonymous", name, preceding)
+		}
+	}
+
+	for _, srvConf := range conf.Servers {
+		srvAC := config.NewAccessControl(srvConf.AccessControl, srvConf.DisableAccessControl)
+		for _, spaConf := range srvConf.SPAs {
+			warnChain(srvAC.Merge(config.NewAccessControl(spaConf.AccessControl, spaConf.DisableAccessControl)).List())
+		}
+		for _, filesConf := range srvConf.Files {
+			warnChain(srvAC.Merge(config.NewAccessControl(filesConf.AccessControl, filesConf.DisableAccessControl)).List())
+		}
+		for _, endpointConf := range srvConf.Endpoints {
+			warnChain(srvAC.Merge(config.NewAccessControl(endpointConf.AccessControl, endpointConf.DisableAccessControl)).List())
+		}
+		for _, apiConf := range srvConf.APIs {
+			apiAC := srvAC.Merge(config.NewAccessControl(apiConf.AccessControl, apiConf.DisableAccessControl))
+			for _, endpointConf := range apiConf.Endpoints {
+				warnChain(apiAC.Merge(config.NewAccessControl(endpointConf.AccessControl, endpointConf.DisableAccessControl)).List())
+			}
+		}
+	}
 }
 
 func configureAccessControls(conf *config.Couper, confCtx *hcl.EvalContext, log *logrus.Entry,

--- a/docs/website/content/configuration/block/beta_authzen.md
+++ b/docs/website/content/configuration/block/beta_authzen.md
@@ -460,7 +460,7 @@ identity into `request.context.<label>` — name the subject from there:
 
 | Access control | Identity in |
 | :------------- | :---------- |
-| `jwt` | `request.context.<label>` holds the token claims. The default subject already carries the bearer token. |
+| `jwt` | `request.context.<label>` holds the token claims. The default subject already carries the token when the control reads it from the `Authorization` header (the default). With `cookie`, `header` or `token_value` set, name the subject from a claim. |
 | `basic_auth` | `request.context.<label>.user` |
 | `saml` | `request.context.<label>.sub` |
 | `oidc` | `request.context.<label>.id_token_claims.sub` |

--- a/docs/website/content/configuration/block/beta_authzen.md
+++ b/docs/website/content/configuration/block/beta_authzen.md
@@ -451,6 +451,49 @@ guidance on when each fits:
 
 > Specification: [OpenFGA: Search With Permissions](https://openfga.dev/docs/interacting/search-with-permissions)
 
+## Naming the subject from a preceding access control
+
+Access controls run in the order of the `access_control` list. Couper evaluates the
+[`subject` attribute](#shaping-the-evaluation-request) after the preceding controls ran.
+The default subject reads only a bearer token. Every other authentication resolves its
+identity into `request.context.<label>` — name the subject from there:
+
+| Access control | Identity in |
+| :------------- | :---------- |
+| `jwt` | `request.context.<label>` holds the token claims. The default subject already carries the bearer token. |
+| `basic_auth` | `request.context.<label>.user` |
+| `saml` | `request.context.<label>.sub` |
+| `oidc` | `request.context.<label>.id_token_claims.sub` |
+| `beta_oauth2` | None. The token response does not have to carry an identity. |
+
+```hcl
+server {
+  api {
+    access_control = ["ba", "pdp"]
+    # ...
+  }
+}
+
+definitions {
+  basic_auth "ba" {
+    htpasswd_file = "htpasswd"
+  }
+
+  beta_authzen "pdp" {
+    url = "https://authorization-service.example.com"
+
+    subject = {
+      type = "identity"
+      id   = request.context.ba.user
+    }
+  }
+}
+```
+
+> Note: Without the `subject` attribute the evaluation asks about `"anonymous"`, although
+> the chain authenticated a caller. Couper logs a warning at startup for such a
+> configuration.
+
 {{< attributes >}}
 [
   {


### PR DESCRIPTION
Stacked on #1000 (`feat/authzen-vscode-generator`). Last PR of the stack.

## Context

The default evaluation subject reads only a bearer token. Behind `basic_auth`, `saml`, `oidc` or `beta_oauth2` it silently stays `anonymous`, although the chain resolved an identity into `request.context.<label>` — a policy keyed on the subject then denies every request, or worse, matches an anonymous rule.

## Changes

- The runtime logs a startup warning when a `beta_authzen` without a `subject` attribute runs behind a non-bearer authentication in any `access_control` chain (server, api, endpoint, spa, files — same merge semantics as the handler wiring). The message names the preceding control and the `request.context` accessor to lift the identity from; `jwt` in front stays silent, since the default subject then carries the very token the chain validated. Deduplicated per pair, pinned by a table test.
- The block documentation gains a closing section with the per-control accessor table and one `basic_auth` example.

<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
