### PR TITLE
ci: move release automation to the couper-svc service account

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,6 +68,9 @@ jobs:
     name: build and publish container image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -90,7 +93,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: |
-            ${{ matrix.image }}
+            docker.io/${{ matrix.image }}
+            ghcr.io/${{ matrix.image }}
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
@@ -112,6 +116,14 @@ jobs:
           #registry: ...
           username: ${{ secrets[matrix.username_key] }}
           password: ${{ secrets[matrix.password_key] }}
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push image with edge tag
         if: github.ref == 'refs/heads/main' && github.event_name == 'push' # due to release branch, pin to main

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -115,7 +115,7 @@ jobs:
       - name: setup git && push
         working-directory: './website'
         run: |
-          git config user.name "couper-bot"
-          git config user.email "couperbot@gmail.com"
+          git config user.name "couper-svc"
+          git config user.email "321729849+couper-svc@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || (git commit -m "Update website" && git push origin main)

--- a/.github/workflows/edge-release.yml
+++ b/.github/workflows/edge-release.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: 'move edge tag'
         run: |
-          git config user.name "couper-bot"
-          git config user.email "couperbot@gmail.com"
+          git config user.name "couper-svc"
+          git config user.email "321729849+couper-svc@users.noreply.github.com"
           git tag -f edge
           git push -f origin edge
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
       - name: 'publish formula'
         env:
           GH_TOKEN: ${{ secrets.GH_COUPER_API_TOKEN }}
-          BRANCH: 'release.${{ github.ref_name }}'
           COMMIT_MSG: 'Update formula to ${{ github.ref_name }} release'
         run: |
           set -euo pipefail
@@ -87,15 +86,6 @@ jobs:
           cd "$workdir"
           git config user.name 'couper-svc'
           git config user.email '321729849+couper-svc@users.noreply.github.com'
-          git switch -c "$BRANCH"
           cp "${GITHUB_WORKSPACE}/.github/workflows/couper.rb" ./couper.rb
           git add couper.rb
-          git commit -m "$COMMIT_MSG"
-          git push --force-with-lease origin "$BRANCH"
-          gh pr view "$BRANCH" --repo coupergateway/homebrew-couper >/dev/null 2>&1 || \
-            gh pr create \
-              --repo coupergateway/homebrew-couper \
-              --base main \
-              --head "$BRANCH" \
-              --title "$COMMIT_MSG" \
-              --body "Automated formula update for ${{ github.ref_name }}."
+          git diff --staged --quiet || (git commit -m "$COMMIT_MSG" && git push origin main)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,8 @@ jobs:
           git clone --depth=1 --branch=main \
             "https://x-access-token:${GH_TOKEN}@github.com/coupergateway/homebrew-couper.git" "$workdir"
           cd "$workdir"
-          git config user.name 'couper-bot'
-          git config user.email 'couperbot@gmail.com'
+          git config user.name 'couper-svc'
+          git config user.email '321729849+couper-svc@users.noreply.github.com'
           git switch -c "$BRANCH"
           cp "${GITHUB_WORKSPACE}/.github/workflows/couper.rb" ./couper.rb
           git add couper.rb

--- a/.github/workflows/vscode-schema.yml
+++ b/.github/workflows/vscode-schema.yml
@@ -60,8 +60,8 @@ jobs:
         if: steps.check_changes.outputs.changed == 'true'
         run: |
           cd couper-vscode
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "couper-svc"
+          git config user.email "321729849+couper-svc@users.noreply.github.com"
           git add generated/schema.json src/schema.js
           git commit -m "chore: sync schema from couper
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ## Getting started
 
 * The quickest way to start is to use our [Docker image](https://hub.docker.com/r/coupergateway/couper).
+  * or from the GitHub Container Registry: `docker pull ghcr.io/coupergateway/couper`
   * or via [homebrew](https://brew.sh/): `brew tap coupergateway/couper && brew install couper`
   * or via Go: `go install github.com/coupergateway/couper@latest`
   * or via [devcontainer feature](https://github.com/coupergateway/features):


### PR DESCRIPTION
All cross-repo automation in this repository pushes as a bot account. That account is now `couper-svc` (`321729849+couper-svc@users.noreply.github.com`), and this PR points every workflow at it. Two adjacent clean-ups ride along, one commit each.

### `ci: commit as the couper-svc service account`

`release.yml` (homebrew formula), `edge-release.yml` (edge tag) and `docs-website.yml` (couper-docs) all set the git identity per step, so all three move over.

`vscode-schema.yml` committed as `github-actions[bot]` although that push runs through the `couper schema sync` deploy key, not the Actions token. It now uses the same identity as the rest, so bot commits in `couper-vscode` are attributable to one account.

The `VSCODE_DEPLOY_KEY` stays as it is — a single-repo deploy key is narrower than a PAT.

### `ci: write the homebrew formula straight to main`

The `brewlease` job pushed a `release.<tag>` branch and opened a PR against `coupergateway/homebrew-couper`. Nobody reviews a generated formula, so the tap stayed behind the tag until somebody merged by hand. The job now copies `couper.rb` onto `main` and pushes; `git diff --staged --quiet ||` keeps re-runs idempotent. `main` in that repo has neither branch protection nor rulesets, so the push goes through. This also drops the `gh` dependency from the step.

### `ci: publish the container image to ghcr.io as well`

`docker/metadata-action` now generates tags for `docker.io/coupergateway/couper` **and** `ghcr.io/coupergateway/couper` in one run, so both the edge push and the release-tag push cover both registries across `linux/amd64` and `linux/arm64` without duplicating any build step.

The registry login uses `GITHUB_TOKEN` with a job-scoped `packages: write`, not a PAT: the package belongs to this repository, so there is no reason to hand a long-lived credential to the push. Docker Hub credentials and the Docker Hub description step are untouched.

`ghcr.io/coupergateway/couper` does not exist yet — the first push creates it. **It is created private, so its visibility needs to be flipped to public once.**

## Deployment notes

Nothing here works until the secret is rotated:

| Repository | Secret | Action |
|---|---|---|
| `coupergateway/couper` | `GH_COUPER_API_TOKEN` | replace the value — the only place the token is consumed (`release.yml`, `docs-website.yml`, `docker.yml`) |
| `coupergateway/couper-website` | `GH_COUPER_API_TOKEN` | orphaned, `website.yml` does not reference it — delete |

The secret name is account-neutral and stays as it is.

`couper-svc` needs `write` on `coupergateway/couper-oidc-gateway`; it currently has `read`, and `repository_dispatch` fails with a 404 below `write`. `homebrew-couper`, `couper-docs` and `couper-vscode` already grant `write`.

Token scope: `repo` covers all three uses.

## Out of scope

`vscode-schema.yml` only triggers on pushes touching `config/**/*.go`, `eval/**/*.go`, `errors/**/*.go` or `config/generate/**`. That filter is unchanged.