### PR TITLE
test: deflake TestConfig_Synced

### DIFF
--- a/internal/test/goroutine.go
+++ b/internal/test/goroutine.go
@@ -9,6 +9,9 @@ import (
 	"strconv"
 )
 
+// NumGoroutines counts all goroutines whose stack contains the filter. The
+// profile groups goroutines by identical stack, so goroutines in the same
+// function can appear in more than one group; all matching groups are summed.
 func NumGoroutines(filter string) (numRoutine int) {
 	profile := pprof.Lookup("goroutine")
 	profileBuf := &bytes.Buffer{}
@@ -16,6 +19,8 @@ func NumGoroutines(filter string) (numRoutine int) {
 	pr := bufio.NewReader(profileBuf)
 
 	stackRegex := regexp.MustCompile(`(\d+)\s@\s0x`)
+	groupCount := 0
+	groupMatched := false
 	for {
 		line, _, readErr := pr.ReadLine()
 		if readErr != nil {
@@ -26,12 +31,14 @@ func NumGoroutines(filter string) (numRoutine int) {
 		}
 		match := stackRegex.FindSubmatch(line)
 		if len(match) > 1 {
-			numRoutine, _ = strconv.Atoi(string(match[1]))
+			groupCount, _ = strconv.Atoi(string(match[1]))
+			groupMatched = false
 			continue
 		}
-		if bytes.Contains(line, []byte(filter)) {
-			return numRoutine
+		if !groupMatched && bytes.Contains(line, []byte(filter)) {
+			numRoutine += groupCount
+			groupMatched = true
 		}
 	}
-	return -1
+	return numRoutine
 }

--- a/internal/test/goroutine_test.go
+++ b/internal/test/goroutine_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"testing"
+	"time"
+)
+
+//go:noinline
+func parkGoroutine(release <-chan struct{}) {
+	<-release
+}
+
+//go:noinline
+func parkGoroutineViaWrapper(release <-chan struct{}) {
+	parkGoroutine(release)
+}
+
+// The pprof goroutine profile groups goroutines by identical stack. Two
+// goroutines in the same function reach it through different call paths, so
+// they land in separate groups. NumGoroutines must sum all matching groups.
+func TestNumGoroutines_SumsAcrossStackGroups(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	go parkGoroutine(release)
+	go parkGoroutineViaWrapper(release)
+
+	var n int
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		n = NumGoroutines("test.parkGoroutine")
+		if n == 2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("expected 2 goroutines in parkGoroutine, got: %d", n)
+}


### PR DESCRIPTION
## Context

`TestConfig_Synced` fails intermittently on slow runs with `Expected two running routines, got: 1`.

## Cause

The goroutine profile (`pprof`, debug=1) groups goroutines by identical stack. `test.NumGoroutines` returned the count of only the first matching stack group. The two `SyncedResource.sync` goroutines run with a 100ms TTL, so a snapshot often catches one of them inside `fetch` — a different stack. The two goroutines then split into two groups of one, and the function returns 1.

## Change

- `NumGoroutines` now sums the counts of all stack groups that contain the filter.
- A unit test reproduces the grouping split deterministically: two goroutines park in the same function, one through an extra wrapper frame.