### PR TITLE
vscode schema: correct two block names and hand over the build

### DIFF
--- a/.github/workflows/vscode-schema.yml
+++ b/.github/workflows/vscode-schema.yml
@@ -35,16 +35,8 @@ jobs:
           ssh-key: ${{ secrets.VSCODE_DEPLOY_KEY }}
           path: couper-vscode
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Copy schema and build
-        run: |
-          cp vscode-schema.json couper-vscode/generated/schema.json
-          cd couper-vscode
-          npm run build:schema
+      - name: Copy schema
+        run: cp vscode-schema.json couper-vscode/generated/schema.json
 
       - name: Check for changes
         id: check_changes
@@ -62,7 +54,7 @@ jobs:
           cd couper-vscode
           git config user.name "couper-svc"
           git config user.email "321729849+couper-svc@users.noreply.github.com"
-          git add generated/schema.json src/schema.js
+          git add generated/schema.json
           git commit -m "chore: sync schema from couper
 
           Auto-generated from coupergateway/couper@${{ github.sha }}"

--- a/config/generate/shared/registry.go
+++ b/config/generate/shared/registry.go
@@ -60,10 +60,12 @@ var BlockNamesMap = map[string]string{
 // Maps internal Go type names to their HCL block names when they differ.
 var VSCodeBlockNamesMap = map[string]string{
 	"auth_zen":        "beta_authzen",
+	"health":          "beta_health",
 	"introspection":   "beta_introspection",
 	"oauth2_ac":       "beta_oauth2",
 	"oauth2_req_auth": "oauth2",
 	"rate_limiter":    "beta_rate_limiter",
+	"token_request":   "beta_token_request",
 	"backend_tls":     "tls",
 	"server_tls":      "tls",
 }


### PR DESCRIPTION
## Context

Follow-up to #1000, which fixed `rate_limiter` in `VSCodeBlockNamesMap`. Two entries of the same kind were still missing.

## Block names

`Health` and `TokenRequest` had no mapping, so the schema keyed them by the Go type name: `health` and `token_request`, while Couper's HCL blocks are `beta_health` and `beta_token_request`.

A wrong key costs more than the name. Parents and descriptions are resolved by block name, so both entries also lost them — `health` was emitted as an empty object, and `beta_rate_limiter` right next to it carries `parents` and a description. After the fix both blocks are complete, and every schema block key is a real HCL block name except `environment`, which is a preprocessed block with no config struct.

## Workflow

The job also built `src/schema.js` inside the extension repository and committed it. That put the extension's build here: a change to its merge script or its overlay only reached the committed output at Couper's next schema change. Couper now pushes `generated/schema.json` and nothing else; the extension rebuilds on its own.

## Merge order

Merge coupergateway/couper-vscode#145 **first**. It adds the reconciler that follows this rename; without it the extension keeps an overlay entry under the old name, and its merge would ship that as a block Couper does not have.