### PR TITLE
Sync the VS Code schema and its rebuild in one commit

### DIFF
--- a/.github/workflows/vscode-schema.yml
+++ b/.github/workflows/vscode-schema.yml
@@ -1,5 +1,10 @@
 name: Sync VS Code Schema
 
+# The extension needs more than the generated file: the hand-maintained
+# overlay has to follow a renamed block, and src/schema.js is built from
+# both. All of it lands in one commit, so couper-vscode never holds a
+# schema that is half applied.
+
 on:
   push:
     branches: [main]
@@ -35,27 +40,50 @@ jobs:
           ssh-key: ${{ secrets.VSCODE_DEPLOY_KEY }}
           path: couper-vscode
 
-      - name: Copy schema
-        run: cp vscode-schema.json couper-vscode/generated/schema.json
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: couper-vscode/package-lock.json
 
-      - name: Check for changes
-        id: check_changes
+      - name: Install couper-vscode dependencies
+        run: npm ci
+        working-directory: couper-vscode
+
+      # A rename the reconciler cannot resolve fails here, which leaves
+      # couper-vscode untouched and names the file to edit.
+      - name: Reconcile the overlay and rebuild the schema
+        id: apply
+        working-directory: couper-vscode
         run: |
-          cd couper-vscode
-          if git diff --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
+          previous="$RUNNER_TEMP/previous-schema.json"
+          cp generated/schema.json "$previous"
+          cp ../vscode-schema.json generated/schema.json
+
+          if git diff --quiet -- generated/schema.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          node scripts/schema-drift.js --fix --baseline "$previous"
+          node scripts/merge-schema.js
+
+      - name: Test couper-vscode
+        if: steps.apply.outputs.changed == 'true'
+        run: npm run jest -- --color
+        working-directory: couper-vscode
 
       - name: Commit and push
-        if: steps.check_changes.outputs.changed == 'true'
+        if: steps.apply.outputs.changed == 'true'
+        working-directory: couper-vscode
         run: |
-          cd couper-vscode
           git config user.name "couper-svc"
           git config user.email "321729849+couper-svc@users.noreply.github.com"
-          git add generated/schema.json
+          git add generated/schema.json src/schema.js src/schema-overlay.json
           git commit -m "chore: sync schema from couper
 
-          Auto-generated from coupergateway/couper@${{ github.sha }}"
+          Generated from coupergateway/couper@${{ github.sha }} and
+          reconciled by scripts/schema-drift.js."
           git push


### PR DESCRIPTION
## Context

The first real sync (couper-vscode 0c3ed84) pushed `generated/schema.json` alone and left the extension inconsistent: the overlay and `src/schema.js` still named the block `health` after Couper had renamed it to `beta_health`. Both workflows on the other side failed.

Splitting the work across two repositories caused three problems at once:

- The follow-up job had no usable push credential. `master` there restricts who may push and the allowlist is empty, which the deploy key bypasses but `GITHUB_TOKEN` does not.
- It could not tell the bot from a human. GitHub attributes a deploy key push to the person who owns the key, so `github.actor` read `malud`.
- It raced the test workflow, which checked the schema on the same commit and could not pass before the rebuild existed.

One commit removes all three. This job now reconciles the overlay, rebuilds `src/schema.js`, runs the extension tests, and commits everything together with the deploy key it already holds.

## Behaviour

- Nothing to sync: the job stops after comparing the generated file.
- A rename the reconciler resolves by itself: applied, tested, pushed as one commit.
- A rename that needs a decision: `schema-drift.js` exits non-zero, this job fails and names the file to edit, and couper-vscode stays untouched rather than receiving a half-applied schema.

## Verification

Replayed locally against couper-vscode at `2be4b58`, the state before the failed sync, with the schema this branch generates:

```
blocks added:   beta_health, beta_token_request
blocks removed: health, token_request
overlay blocks: "health" -> "beta_health" (migrated, matched via beta_ prefix)
```

150 tests pass, and all three resulting files are byte-identical to the state that had to be repaired by hand in coupergateway/couper-vscode#146.

## Merge order

Merge coupergateway/couper-vscode#146 first. It repairs `master` and removes the workflow this change replaces.
