### PR TITLE
chore(deps): build with go 1.26.8 for the 1.14.3 patch release

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.8'
 
       - name: Install dependencies
         run: go mod download
@@ -212,7 +212,7 @@ jobs:
         if: steps.freshness.outputs.skip != 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.8'
 
       - name: Install dependencies
         if: steps.freshness.outputs.skip != 'true'

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.8'
         id: go
       - run: go version
 

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.8'
       - uses: actions/checkout@v4
       - name: Dependencies
         run: go mod download

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5.0.0
       with:
-        go-version: '1.26.2'
+        go-version: '1.26.8'
       id: go
     - run: go version
 

--- a/.github/workflows/weekly-fuzz.yml
+++ b/.github/workflows/weekly-fuzz.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.8'
         id: go
       - run: go version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Couper Changelog
 
-## [Unreleased](https://github.com/coupergateway/couper/compare/v1.14.2...main)
+## [Unreleased](https://github.com/coupergateway/couper/compare/v1.14.3...main)
 
 Unreleased changes are available as `coupergateway/couper:edge` container.
 
 ---
+
+## [1.14.3](https://github.com/coupergateway/couper/releases/tag/v1.14.3)
+
+* **Security**
+  * build with [go 1.26.8](https://go.dev/doc/devel/release#go1.26.8) — security fixes for `crypto/tls`, `crypto/x509`, `encoding/asn1`, `encoding/xml`, `html/template`, `mime`, `net`, `net/http`, `net/http/httputil`, `net/mail`, `net/textproto`, `net/url`, `os` and `syscall` ([#1007](https://github.com/coupergateway/couper/pull/1007))
 
 ## [1.14.2](https://github.com/coupergateway/couper/releases/tag/v1.14.2)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.8 AS builder
 
 WORKDIR /go/src/app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coupergateway/couper
 
-go 1.26.2
+go 1.26.8
 
 require (
 	github.com/docker/go-units v0.5.0


### PR DESCRIPTION
## Context

`release.1.14` builds with go 1.26.2. Every patch release from 1.26.3 to 1.26.6 corrects security
defects in the standard-library packages Couper uses on each request path:

| Release | Security fixes in |
|---|---|
| 1.26.3 | `html/template`, `net`, `net/http`, `net/http/httputil`, `net/mail`, `syscall` |
| 1.26.4 | `crypto/x509`, `mime`, `net/textproto` |
| 1.26.5 | `crypto/tls`, `os` |
| 1.26.6 | `crypto/tls`, `encoding/asn1`, `encoding/xml`, `html/template`, `net`, `net/http`, `net/url` |

1.26.7 and 1.26.8 contain functional fixes only. This pins the current patch level, 1.26.8.

## Changes

- `go.mod` go directive and the `Dockerfile` builder image
- CI pins in `go.yml`, `go-coverage.yml`, `weekly-fuzz.yml`, `docs-website.yml` and `claude-code.yml`
- `release.yml` and `edge-release.yml` keep their minor-only `goversion: '1.26'` pin, so they follow
  the patch level without a change

## Part of the 1.14.3 patch release

This PR opens the `1.14.3` CHANGELOG section. The other parts merge on top of it:

- module security bumps: `kin-openapi`, `grpc`, `golang.org/x/net`, `golang.org/x/crypto`
- #969 — forward HTTP/2 backend response trailers
- argon2 `htpasswd` hardening for #866

Successor: #1008 (module security bumps).