### PR TITLE
metrics: scale the duration histogram buckets to seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Unreleased changes are available as `coupergateway/couper:edge` container.
 
 * **Fixed**
   * Forward HTTP/2 backend response trailers (e.g. gRPC `grpc-status`) to the client instead of dropping them ([#968](https://github.com/coupergateway/couper/issues/968))
+  * metrics: bucket boundaries for the duration histograms — the SDK defaults (`5` … `10000`) assume milliseconds while Couper records seconds, so every observation fell into the first bucket and `histogram_quantile` returned the quantile fraction of `5s` rather than a measurement. `couper_backend_connections_lifetime_seconds` gets a wider ladder, because a pooled keep-alive connection outlives a request by orders of magnitude ([#1010](https://github.com/coupergateway/couper/issues/1010))
 
 * **Dependencies**
   * `github.com/getkin/kin-openapi` 0.133.0 → 0.144.0 ([#1008](https://github.com/coupergateway/couper/pull/1008))

--- a/handler/access_control.go
+++ b/handler/access_control.go
@@ -37,7 +37,8 @@ func (a *AccessControl) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	meter := provider.Meter(instrumentation.AccessControlInstrumentationName)
 	counter, _ := meter.Int64Counter(instrumentation.AccessControlTotal)
-	duration, _ := meter.Float64Histogram(instrumentation.AccessControlDuration)
+	duration, _ := meter.Float64Histogram(instrumentation.AccessControlDuration,
+		metric.WithExplicitBucketBoundaries(instrumentation.DefaultDurationSecondsBoundaries...))
 	rateLimitedCounter, _ := meter.Int64Counter(instrumentation.AccessControlRateLimited)
 
 	for _, control := range a.acl {

--- a/handler/middleware/metrics.go
+++ b/handler/middleware/metrics.go
@@ -41,7 +41,8 @@ func (mh *MetricsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	meter := provider.Meter("couper/server")
 
 	counter, _ := meter.Int64Counter(instrumentation.ClientRequest)
-	duration, _ := meter.Float64Histogram(instrumentation.ClientRequestDuration)
+	duration, _ := meter.Float64Histogram(instrumentation.ClientRequestDuration,
+		metric.WithExplicitBucketBoundaries(instrumentation.DefaultDurationSecondsBoundaries...))
 
 	option := metric.WithAttributes(metricsAttrs...)
 	counter.Add(req.Context(), 1, option)

--- a/handler/middleware/metrics.go
+++ b/handler/middleware/metrics.go
@@ -14,20 +14,22 @@ import (
 
 type MetricsHandler struct {
 	handler http.Handler
+	clock   func() time.Time
 }
 
 func NewMetricsHandler() Next {
 	return func(handler http.Handler) *NextHandler {
 		return NewHandler(&MetricsHandler{
 			handler: handler,
+			clock:   time.Now,
 		}, handler)
 	}
 }
 
 func (mh *MetricsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	start := time.Now()
+	start := mh.clock()
 	mh.handler.ServeHTTP(rw, req)
-	end := time.Since(start)
+	elapsed := mh.clock().Sub(start)
 
 	metricsAttrs := []attribute.KeyValue{
 		attribute.String("host", req.Host),
@@ -46,5 +48,5 @@ func (mh *MetricsHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	option := metric.WithAttributes(metricsAttrs...)
 	counter.Add(req.Context(), 1, option)
-	duration.Record(req.Context(), end.Seconds(), option)
+	duration.Record(req.Context(), elapsed.Seconds(), option)
 }

--- a/handler/middleware/metrics_test.go
+++ b/handler/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,14 +9,16 @@ import (
 
 	prom "github.com/prometheus/client_golang/prometheus"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/coupergateway/couper/telemetry/instrumentation"
 	"github.com/coupergateway/couper/telemetry/provider"
 )
 
-// serveWithMetrics returns the exported bucket boundaries and their cumulative counts.
-func serveWithMetrics(t *testing.T, handlerDelay time.Duration) ([]float64, []uint64) {
+// serveWithMetrics serves one request through handler and returns the exported bucket
+// boundaries of the client request duration histogram and their cumulative counts.
+func serveWithMetrics(t *testing.T, handler http.Handler) ([]float64, []uint64) {
 	t.Helper()
 
 	registry := prom.NewRegistry()
@@ -27,13 +30,15 @@ func serveWithMetrics(t *testing.T, handlerDelay time.Duration) ([]float64, []ui
 	if err != nil {
 		t.Fatal(err)
 	}
-	provider.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter)))
 
-	inner := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
-		time.Sleep(handlerDelay)
-		rw.WriteHeader(http.StatusOK)
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+	provider.SetMeterProvider(meterProvider)
+	t.Cleanup(func() {
+		_ = meterProvider.Shutdown(context.Background())
+		provider.SetMeterProvider(noop.NewMeterProvider())
 	})
-	NewMetricsHandler()(inner).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
 
 	families, err := registry.Gather()
 	if err != nil {
@@ -61,7 +66,11 @@ func serveWithMetrics(t *testing.T, handlerDelay time.Duration) ([]float64, []ui
 }
 
 func TestMetricsHandler_DefaultBucketBoundaries(t *testing.T) {
-	bounds, _ := serveWithMetrics(t, 0)
+	inner := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	bounds, _ := serveWithMetrics(t, NewMetricsHandler()(inner))
 
 	want := instrumentation.DefaultDurationSecondsBoundaries
 	if len(bounds) != len(want) {
@@ -76,7 +85,17 @@ func TestMetricsHandler_DefaultBucketBoundaries(t *testing.T) {
 
 // The SDK's default boundaries put every request faster than 5s into one bucket.
 func TestMetricsHandler_ResolvesSubSecondDurations(t *testing.T) {
-	bounds, counts := serveWithMetrics(t, 25*time.Millisecond)
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	// The handler advances the clock instead of sleeping, so the recorded duration
+	// is exactly 25ms on every machine.
+	inner := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		now = now.Add(25 * time.Millisecond)
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	bounds, counts := serveWithMetrics(t, &MetricsHandler{handler: inner, clock: clock})
 
 	capturedAt := -1
 	for i, count := range counts {
@@ -90,7 +109,8 @@ func TestMetricsHandler_ResolvesSubSecondDurations(t *testing.T) {
 		t.Fatalf("observation was not recorded: %v", counts)
 	}
 
-	if bounds[capturedAt] > 0.1 {
-		t.Errorf("a 25ms request was first captured at le=%v; the boundaries do not resolve sub-second durations", bounds[capturedAt])
+	const want = 0.025
+	if bounds[capturedAt] != want {
+		t.Errorf("a 25ms request was first captured at le=%v, want le=%v", bounds[capturedAt], want)
 	}
 }

--- a/handler/middleware/metrics_test.go
+++ b/handler/middleware/metrics_test.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/coupergateway/couper/telemetry/instrumentation"
+	"github.com/coupergateway/couper/telemetry/provider"
+)
+
+// serveWithMetrics returns the exported bucket boundaries and their cumulative counts.
+func serveWithMetrics(t *testing.T, handlerDelay time.Duration) ([]float64, []uint64) {
+	t.Helper()
+
+	registry := prom.NewRegistry()
+	exporter, err := otelprom.New(
+		otelprom.WithRegisterer(registry),
+		otelprom.WithoutScopeInfo(),
+		otelprom.WithoutTargetInfo(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter)))
+
+	inner := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		time.Sleep(handlerDelay)
+		rw.WriteHeader(http.StatusOK)
+	})
+	NewMetricsHandler()(inner).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != instrumentation.ClientRequestDuration {
+			continue
+		}
+
+		var bounds []float64
+		var counts []uint64
+		for _, bucket := range family.GetMetric()[0].GetHistogram().GetBucket() {
+			bounds = append(bounds, bucket.GetUpperBound())
+			counts = append(counts, bucket.GetCumulativeCount())
+		}
+
+		return bounds, counts
+	}
+
+	t.Fatalf("%s not exported", instrumentation.ClientRequestDuration)
+
+	return nil, nil
+}
+
+func TestMetricsHandler_DefaultBucketBoundaries(t *testing.T) {
+	bounds, _ := serveWithMetrics(t, 0)
+
+	want := instrumentation.DefaultDurationSecondsBoundaries
+	if len(bounds) != len(want) {
+		t.Fatalf("want %d boundaries, got %d: %v", len(want), len(bounds), bounds)
+	}
+	for i, boundary := range want {
+		if bounds[i] != boundary {
+			t.Errorf("boundary %d: want %v, got %v", i, boundary, bounds[i])
+		}
+	}
+}
+
+// The SDK's default boundaries put every request faster than 5s into one bucket.
+func TestMetricsHandler_ResolvesSubSecondDurations(t *testing.T) {
+	bounds, counts := serveWithMetrics(t, 25*time.Millisecond)
+
+	capturedAt := -1
+	for i, count := range counts {
+		if count > 0 {
+			capturedAt = i
+			break
+		}
+	}
+
+	if capturedAt < 0 {
+		t.Fatalf("observation was not recorded: %v", counts)
+	}
+
+	if bounds[capturedAt] > 0.1 {
+		t.Errorf("a 25ms request was first captured at le=%v; the boundaries do not resolve sub-second durations", bounds[capturedAt])
+	}
+}

--- a/handler/transport/connection.go
+++ b/handler/transport/connection.go
@@ -86,7 +86,8 @@ func (o *OriginConn) logFields(event string) logrus.Fields {
 		since := time.Since(o.createdAt)
 
 		meter := provider.Meter("couper/connection")
-		duration, _ := meter.Float64Histogram(instrumentation.BackendConnectionsLifetime)
+		duration, _ := meter.Float64Histogram(instrumentation.BackendConnectionsLifetime,
+			metric.WithExplicitBucketBoundaries(instrumentation.ConnectionLifetimeSecondsBoundaries...))
 		duration.Record(context.Background(), since.Seconds(), metric.WithAttributes(o.labels...))
 
 		fields["lifetime"] = since.Milliseconds()

--- a/telemetry/instrumentation/instrumentation.go
+++ b/telemetry/instrumentation/instrumentation.go
@@ -23,3 +23,17 @@ const (
 	AccessControlRateLimited     = Prefix + "access_control_rate_limited_total"
 	AccessControlRateLimiterKeys = Prefix + "access_control_rate_limiter_active_keys"
 )
+
+// DefaultDurationSecondsBoundaries are the boundaries the OpenTelemetry semantic conventions
+// specify for HTTP request duration. The SDK's own defaults assume milliseconds.
+var DefaultDurationSecondsBoundaries = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+}
+
+// ConnectionLifetimeSecondsBoundaries cover the lifetime of a backend connection. Couper
+// leaves the transport's IdleConnTimeout unset, so a pooled keep-alive connection lives
+// until the origin closes it — minutes or hours rather than the seconds a request takes.
+// DefaultDurationSecondsBoundaries would collapse nearly every observation into +Inf.
+var ConnectionLifetimeSecondsBoundaries = []float64{
+	0.1, 0.5, 1, 5, 10, 30, 60, 300, 900, 1800, 3600, 7200,
+}

--- a/telemetry/transport.go
+++ b/telemetry/transport.go
@@ -63,7 +63,8 @@ func (t *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	// Metrics setup
 	meter := provider.Meter(instrumentation.BackendInstrumentationName)
 	counter, _ := meter.Int64Counter(instrumentation.BackendRequest)
-	duration, _ := meter.Float64Histogram(instrumentation.BackendRequestDuration)
+	duration, _ := meter.Float64Histogram(instrumentation.BackendRequestDuration,
+		metric.WithExplicitBucketBoundaries(instrumentation.DefaultDurationSecondsBoundaries...))
 
 	attrs := []attribute.KeyValue{
 		attribute.String("backend_name", backendName),


### PR DESCRIPTION
Split out of #1011 as requested, so the fix can ship in 1.14.3.

The duration histograms record seconds but were created without explicit bucket boundaries, so they inherited the SDK defaults (`5` … `10000`), which are calibrated for milliseconds. Every request faster than 5s fell into the first bucket, and `histogram_quantile` returned the quantile fraction of `5s` rather than a measurement — including for the dashboard shipped as `grafana.json`.

This PR sets the boundaries the OpenTelemetry semantic conventions specify for HTTP request duration on `couper_client_request_duration_seconds`, `couper_backend_request_duration_seconds` and `couper_access_control_duration_seconds`. `NewMetricsHandler` keeps its signature.

### On the connection lifetime histogram

You were right to ask, and it is worse than a 10s ceiling being merely tight: `handler/transport/transport.go` builds the transport without an `IdleConnTimeout`, so a pooled keep-alive connection lives until the origin closes it — minutes or hours. Against the request-duration ladder nearly every observation would land in `+Inf` and the quantiles would stay as useless as before the fix.

So `couper_backend_connections_lifetime_seconds` gets its own ladder, `instrumentation.ConnectionLifetimeSecondsBoundaries`:

```
0.1, 0.5, 1, 5, 10, 30, 60, 300, 900, 1800, 3600, 7200
```

The low end still resolves connections that fail or are closed immediately; the top end reaches the long-lived pooled connections. Happy to shift it if you have a different picture of the lifetimes you see in practice.

### Tests

`handler/middleware/metrics_test.go` exports the histogram through a real Prometheus registry and asserts the boundaries:

- `TestMetricsHandler_DefaultBucketBoundaries` — the exported ladder is the second-based one.
- `TestMetricsHandler_ResolvesSubSecondDurations` — a 25ms request is captured at `le<=0.1`. Under the SDK defaults it landed at `le=5`.

### Follow-up

`beta_metrics_request_duration_buckets` and its docs are dropped here and will follow against `main` once this is forward-merged, as you suggested.
